### PR TITLE
Implemented periodic boundaries.

### DIFF
--- a/src/CMacIonize.cpp
+++ b/src/CMacIonize.cpp
@@ -148,8 +148,9 @@ int main(int argc, char **argv) {
       Photon photon = source.get_random_photon();
       double tau = -std::log(Utilities::random_double());
       while (grid.interact(photon, tau)) {
-        if (!source.reemit(photon, grid.get_cell_values(grid.get_cell_indices(
-                                       photon.get_position())),
+        CoordinateVector< int > new_index =
+            grid.get_cell_indices(photon.get_position());
+        if (!source.reemit(photon, grid.get_cell_values(new_index),
                            params.get_value< double >("helium_abundance"))) {
           break;
         }

--- a/src/DensityGrid.hpp
+++ b/src/DensityGrid.hpp
@@ -48,6 +48,9 @@ private:
   /*! @brief Box containing the grid. */
   Box _box;
 
+  /*! @brief Periodicity flags. */
+  CoordinateVector< bool > _periodic;
+
   /*! @brief Side lengths of a single cell. */
   CoordinateVector<> _cellside;
 
@@ -70,9 +73,12 @@ private:
   Log *_log;
 
 public:
-  DensityGrid(Box box, CoordinateVector< int > ncell, double helium_abundance,
-              double initial_temperature, DensityFunction &density_function,
-              RecombinationRates &recombination_rates, Log *log = nullptr);
+  DensityGrid(
+      Box box, CoordinateVector< int > ncell, double helium_abundance,
+      double initial_temperature, DensityFunction &density_function,
+      RecombinationRates &recombination_rates,
+      CoordinateVector< bool > periodic = CoordinateVector< bool >(false),
+      Log *log = nullptr);
 
   DensityGrid(ParameterFile &parameters, DensityFunction &density_function,
               RecombinationRates &recombination_rates, Log *log = nullptr);
@@ -87,7 +93,7 @@ public:
   CoordinateVector< int > get_cell_indices(CoordinateVector<> position);
   Box get_cell(CoordinateVector< int > index);
   DensityValues &get_cell_values(CoordinateVector< int > index);
-  bool is_inside(CoordinateVector< int > index);
+  bool is_inside(CoordinateVector< int > &index, CoordinateVector<> &position);
   CoordinateVector<> get_wall_intersection(CoordinateVector<> &photon_origin,
                                            CoordinateVector<> &photon_direction,
                                            Box &cell,


### PR DESCRIPTION
Added support for radiative transfer with periodic boundaries. The simulation box has boundaries in three dimensions, and the periodicity of the border in each dimension can be specified separately. This makes it possible e.g. to post-process hydrodynamical simulations with periodic x and y boundaries and an open z boundary (SILCC).