### PR TITLE
BlockSyntaxDensityFunction

### DIFF
--- a/src/BlockSyntaxBlock.hpp
+++ b/src/BlockSyntaxBlock.hpp
@@ -1,0 +1,91 @@
+/*******************************************************************************
+ * This file is part of CMacIonize
+ * Copyright (C) 2016 Bert Vandenbroucke (bert.vandenbroucke@gmail.com)
+ *
+ * CMacIonize is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CMacIonize is distributed in the hope that it will be useful,
+ * but WITOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with CMacIonize. If not, see <http://www.gnu.org/licenses/>.
+ ******************************************************************************/
+
+/**
+ * @file BlockSyntaxBlock.hpp
+ *
+ * @brief Block structure used in the BlockSyntaxDensityFunction.
+ *
+ * @author Bert Vandenbroucke (bv7@st-andrews.ac.uk)
+ */
+#ifndef BLOCKSYNTAXBLOCK_HPP
+#define BLOCKSYNTAXBLOCK_HPP
+
+#include "CoordinateVector.hpp"
+
+/**
+ * @brief Block structure used in the BlockSyntaxDensityFunction.
+ */
+class BlockSyntaxBlock {
+private:
+  /*! @brief Origin of the block. */
+  CoordinateVector<> _origin;
+
+  /*! @brief Side lengths of the block. */
+  CoordinateVector<> _sides;
+
+  /*! @brief Exponent of the block. */
+  double _exponent;
+
+  /*! @brief Density inside the block. */
+  double _density;
+
+public:
+  /**
+   * @brief Empty constructor.
+   */
+  inline BlockSyntaxBlock() : _density(0.) {}
+
+  /**
+   * @brief Constructor.
+   *
+   * @param origin Origin of the block.
+   * @param sides Side lengths of the block.
+   * @param exponent Exponent of the block.
+   * @param density Density inside the block.
+   */
+  inline BlockSyntaxBlock(CoordinateVector<> origin, CoordinateVector<> sides,
+                          double exponent, double density)
+      : _origin(origin), _sides(sides), _exponent(exponent), _density(density) {
+  }
+
+  /**
+   * @brief Check if the given position lies inside this block.
+   *
+   * @param position CoordinateVector specifying a position.
+   * @return True if the position lies inside this block.
+   */
+  inline bool is_inside(CoordinateVector<> position) {
+    double r = 0.;
+    for (unsigned int i = 0; i < 3; ++i) {
+      double x = 2. * std::abs(position[i] - _origin[i]) / _sides[i];
+      r += std::pow(x, _exponent);
+    }
+    r = std::pow(r, 1. / _exponent);
+    return r <= 1.;
+  }
+
+  /**
+   * @brief Get the number density inside this block.
+   *
+   * @return Number density inside this block (in m^-3).
+   */
+  inline double get_density() { return _density; }
+};
+
+#endif // BLOCKSYNTAXBLOCK_HPP

--- a/src/BlockSyntaxBlock.hpp
+++ b/src/BlockSyntaxBlock.hpp
@@ -27,6 +27,7 @@
 #define BLOCKSYNTAXBLOCK_HPP
 
 #include "CoordinateVector.hpp"
+#include "Error.hpp"
 
 /**
  * @brief Block structure used in the BlockSyntaxDensityFunction.
@@ -74,9 +75,15 @@ public:
     double r = 0.;
     for (unsigned int i = 0; i < 3; ++i) {
       double x = 2. * std::abs(position[i] - _origin[i]) / _sides[i];
-      r += std::pow(x, _exponent);
+      if (_exponent < 10.) {
+        r += std::pow(x, _exponent);
+      } else {
+        r = std::max(r, x);
+      }
     }
-    r = std::pow(r, 1. / _exponent);
+    if (_exponent < 10.) {
+      r = std::pow(r, 1. / _exponent);
+    }
     return r <= 1.;
   }
 

--- a/src/BlockSyntaxDensityFunction.hpp
+++ b/src/BlockSyntaxDensityFunction.hpp
@@ -29,6 +29,7 @@
 
 #include "BlockSyntaxBlock.hpp"
 #include "DensityFunction.hpp"
+#include "Log.hpp"
 #include "ParameterFile.hpp"
 
 #include <sstream>
@@ -66,8 +67,9 @@ public:
    * @brief Constructor.
    *
    * @param filename Name of the YAML file containing the block information.
+   * @param log Log to write logging info to.
    */
-  BlockSyntaxDensityFunction(std::string filename) {
+  BlockSyntaxDensityFunction(std::string filename, Log *log = nullptr) {
     ParameterFile blockfile(filename);
 
     const int numblock = blockfile.get_value< int >("number of blocks");
@@ -90,7 +92,22 @@ public:
       }
       _blocks.push_back(BlockSyntaxBlock(origin, sides, exponent, density));
     }
+
+    if (log) {
+      log->write_status("Created BlockSyntaxDensityFunction with ", numblock,
+                        " blocks.");
+    }
   }
+
+  /**
+   * @brief ParameterFile constructor.
+   *
+   * @param params ParameterFile to read.
+   * @param log Log to write logging info to.
+   */
+  BlockSyntaxDensityFunction(ParameterFile &params, Log *log = nullptr)
+      : BlockSyntaxDensityFunction(
+            params.get_value< std::string >("densityfunction.filename"), log) {}
 
   /**
    * @brief Function that gives the density for a given coordinate.

--- a/src/BlockSyntaxDensityFunction.hpp
+++ b/src/BlockSyntaxDensityFunction.hpp
@@ -1,0 +1,116 @@
+/*******************************************************************************
+ * This file is part of CMacIonize
+ * Copyright (C) 2016 Bert Vandenbroucke (bert.vandenbroucke@gmail.com)
+ *
+ * CMacIonize is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CMacIonize is distributed in the hope that it will be useful,
+ * but WITOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with CMacIonize. If not, see <http://www.gnu.org/licenses/>.
+ ******************************************************************************/
+
+/**
+ * @file BlockSyntaxDensityFunction.hpp
+ *
+ * @brief DensityFunction implementation that constructs a density field based
+ * on geometrical building blocks specified in a YAML file.
+ *
+ * @author Bert Vandenbroucke (bv7@st-andrews.ac.uk)
+ */
+#ifndef BLOCKSYNTAXDENSITYFUNCTION_HPP
+#define BLOCKSYNTAXDENSITYFUNCTION_HPP
+
+#include "BlockSyntaxBlock.hpp"
+#include "DensityFunction.hpp"
+#include "ParameterFile.hpp"
+
+#include <sstream>
+
+/**
+ * @brief DensityFunction implementation that constructs a density field based
+ * on geometrical building blocks specified in a YAML file.
+ */
+class BlockSyntaxDensityFunction : public DensityFunction {
+private:
+  /*! @brief Geometrical building blocks. */
+  std::vector< BlockSyntaxBlock > _blocks;
+
+  /**
+   * @brief Get the exponent corresponding to a given block type.
+   *
+   * @param type Type of block.
+   * @return Exponent corresponding to that type.
+   */
+  inline double get_exponent(std::string type) {
+    if (type == "rhombus") {
+      return 1.;
+    } else if (type == "sphere") {
+      return 2.;
+    } else if (type == "cube") {
+      return 10.;
+    } else {
+      error("Unknown block type: \"%s\"!", type.c_str());
+      return 0.;
+    }
+  }
+
+public:
+  /**
+   * @brief Constructor.
+   *
+   * @param filename Name of the YAML file containing the block information.
+   */
+  BlockSyntaxDensityFunction(std::string filename) {
+    ParameterFile blockfile(filename);
+
+    const int numblock = blockfile.get_value< int >("number of blocks");
+    for (int i = 0; i < numblock; ++i) {
+      std::stringstream blockname;
+      blockname << "block[" << i << "]";
+      CoordinateVector<> origin =
+          blockfile.get_physical_vector< QUANTITY_LENGTH >(blockname.str() +
+                                                           ".origin");
+      CoordinateVector<> sides =
+          blockfile.get_physical_vector< QUANTITY_LENGTH >(blockname.str() +
+                                                           ".sides");
+      std::string type =
+          blockfile.get_value< std::string >(blockname.str() + ".type");
+      double exponent = get_exponent(type);
+      double density = blockfile.get_physical_value< QUANTITY_NUMBER_DENSITY >(
+          blockname.str() + ".number density");
+      if (density < 0.) {
+        error("Negative density (%g) given for block %i!", density, i);
+      }
+      _blocks.push_back(BlockSyntaxBlock(origin, sides, exponent, density));
+    }
+  }
+
+  /**
+   * @brief Function that gives the density for a given coordinate.
+   *
+   * @param position CoordinateVector specifying a coordinate position (in m).
+   * @return Density at the given coordinate (in m^-3).
+   */
+  virtual double operator()(CoordinateVector<> position) {
+    double density = -1.;
+    for (unsigned int i = 0; i < _blocks.size(); ++i) {
+      if (_blocks[i].is_inside(position)) {
+        density = _blocks[i].get_density();
+      }
+    }
+    if (density < 0.) {
+      error("No block found containing position [%g m, %g m, %g m]!",
+            position.x(), position.y(), position.z());
+    }
+    return density;
+  }
+};
+
+#endif // BLOCKSYNTAXDENSITYFUNCTION_HPP

--- a/src/DensityFunctionFactory.hpp
+++ b/src/DensityFunctionFactory.hpp
@@ -94,10 +94,10 @@ public:
     // on library name). Each group is sorted alphabetically as well.
     if (type == "AsciiFile") {
       return new AsciiFileDensityFunction(params, log);
-    } else if (type == "Homogeneous") {
-      return new HomogeneousDensityFunction(params, log);
     } else if (type == "BlockSyntax") {
       return new BlockSyntaxDensityFunction(params, log);
+    } else if (type == "Homogeneous") {
+      return new HomogeneousDensityFunction(params, log);
 #ifdef HAVE_HDF5
     } else if (type == "FLASHSnapshot") {
       return new FLASHSnapshotDensityFunction(params, log);

--- a/src/DensityFunctionFactory.hpp
+++ b/src/DensityFunctionFactory.hpp
@@ -34,6 +34,7 @@
 
 // non library dependent implementations
 #include "AsciiFileDensityFunction.hpp"
+#include "BlockSyntaxDensityFunction.hpp"
 #include "HomogeneousDensityFunction.hpp"
 
 // HDF5 dependent implementations
@@ -95,6 +96,8 @@ public:
       return new AsciiFileDensityFunction(params, log);
     } else if (type == "Homogeneous") {
       return new HomogeneousDensityFunction(params, log);
+    } else if (type == "BlockSyntax") {
+      return new BlockSyntaxDensityFunction(params, log);
 #ifdef HAVE_HDF5
     } else if (type == "FLASHSnapshot") {
       return new FLASHSnapshotDensityFunction(params, log);

--- a/src/IsotropicContinuousPhotonSource.hpp
+++ b/src/IsotropicContinuousPhotonSource.hpp
@@ -1,0 +1,137 @@
+/*******************************************************************************
+ * This file is part of CMacIonize
+ * Copyright (C) 2016 Bert Vandenbroucke (bert.vandenbroucke@gmail.com)
+ *
+ * CMacIonize is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CMacIonize is distributed in the hope that it will be useful,
+ * but WITOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with CMacIonize. If not, see <http://www.gnu.org/licenses/>.
+ ******************************************************************************/
+
+/**
+ * @file IsotropicContinuousPhotonSource.hpp
+ *
+ * @brief Class used to generate an isotropic external radiation field.
+ *
+ * @author Bert Vandenbroucke (bv7@st-andrews.ac.uk)
+ */
+#ifndef ISOTROPICCONTINUOUSPHOTONSOURCE_HPP
+#define ISOTROPICCONTINUOUSPHOTONSOURCE_HPP
+
+#include "Box.hpp"
+#include "CoordinateVector.hpp"
+#include "RandomGenerator.hpp"
+#include <cfloat>
+
+/**
+ * @brief Class used to generate an isotropic external radiation field.
+ */
+class IsotropicContinuousPhotonSource {
+private:
+  /*! @brief Box in which the radiation enters. */
+  Box _box;
+
+  /*! @brief Random generator. */
+  RandomGenerator &_random_generator;
+
+public:
+  /**
+   * @brief Constructor.
+   *
+   * @param box Box in which the radiation enters.
+   * @param random_generator Random generator.
+   */
+  IsotropicContinuousPhotonSource(Box box, RandomGenerator &random_generator)
+      : _box(box), _random_generator(random_generator) {}
+
+  /**
+   * @brief Get the entrance position and direction of a random external photon.
+   *
+   * @return std::pair of CoordinateVector instances, specifying a starting
+   * position and direction for an incoming photon.
+   */
+  std::pair< CoordinateVector<>, CoordinateVector<> >
+  get_random_incoming_direction() {
+    // we randomly sample a focus point in the box
+    CoordinateVector<> focus;
+    focus[0] =
+        _box.get_anchor().x() +
+        _box.get_sides().x() * _random_generator.get_uniform_random_double();
+    focus[1] =
+        _box.get_anchor().y() +
+        _box.get_sides().y() * _random_generator.get_uniform_random_double();
+    focus[2] =
+        _box.get_anchor().z() +
+        _box.get_sides().z() * _random_generator.get_uniform_random_double();
+
+    // random incoming direction for the focus point
+    double cost = 2. * _random_generator.get_uniform_random_double() - 1.;
+    double sint = 1. - cost * cost;
+    sint = std::sqrt(std::max(sint, 0.));
+    double phi = 2. * M_PI * _random_generator.get_uniform_random_double();
+    double cosp = std::cos(phi);
+    double sinp = std::sin(phi);
+    CoordinateVector<> direction(sint * cosp, sint * sinp, cost);
+
+    // the direction and the focus point define a line:
+    //   line = focus + t * direction.
+    // with t a parameter.
+    // find the intersection points of this line with the walls of the box
+    // the origin of the random photon is the intersection point with negative
+    // t value
+    CoordinateVector<> anchor_bottom = _box.get_anchor();
+    CoordinateVector<> anchor_top = _box.get_top_anchor();
+
+    // the box has 6 faces, each of which has an intersection point with the
+    // line. If the focus point is inside the box (which it should be), then
+    // 3 intersection points will have a negative parameter value, and 3 will
+    // have a positive value
+    // we record all 3 negative values, and then pick the one with the largest
+    // parameter value (smallest absolute value), since this intersection point
+    // is the closest
+    double lx, ly, lz;
+    if (direction.x() < 0.) {
+      lx = (anchor_top.x() - focus.x()) / direction.x();
+    } else if (direction.x() > 0.) {
+      lx = (anchor_bottom.x() - focus.x()) / direction.x();
+    } else {
+      // the line is parallel to the x faces
+      // make sure this intersection point has the largest absolute parameter
+      // value
+      lx = -DBL_MAX;
+    }
+
+    if (direction.y() < 0.) {
+      ly = (anchor_top.y() - focus.y()) / direction.y();
+    } else if (direction.y() > 0.) {
+      ly = (anchor_bottom.y() - focus.y()) / direction.y();
+    } else {
+      ly = -DBL_MAX;
+    }
+
+    if (direction.z() < 0.) {
+      lz = (anchor_top.z() - focus.z()) / direction.z();
+    } else if (direction.z() > 0.) {
+      lz = (anchor_bottom.z() - focus.z()) / direction.z();
+    } else {
+      lz = -DBL_MAX;
+    }
+
+    double maxl = std::max(lx, ly);
+    maxl = std::max(maxl, lz);
+
+    CoordinateVector<> position = focus + maxl * direction;
+
+    return std::make_pair(position, direction);
+  }
+};
+
+#endif // ISOTROPICCONTINUOUSPHOTONSOURCE_HPP

--- a/src/PhotonSource.hpp
+++ b/src/PhotonSource.hpp
@@ -55,25 +55,42 @@ class PhotonSourceSpectrum;
  */
 class PhotonSource {
 private:
+  /// discrete sources
+
   /*! @brief Total number of photons emitted by all discrete sources. */
-  unsigned int _number_of_photons;
+  unsigned int _discrete_number_of_photons;
   /*! @brief Number of photons emitted by the currently active source. */
-  unsigned int _active_number_of_photons;
+  unsigned int _discrete_active_number_of_photons;
   /*! @brief Currently emitted photon index. */
-  unsigned int _active_photon_index;
+  unsigned int _discrete_active_photon_index;
   /*! @brief Currently active photon source index. */
-  unsigned int _active_source_index;
+  unsigned int _discrete_active_source_index;
 
   /*! @brief Positions of the discrete photon sources (in m). */
-  std::vector< CoordinateVector<> > _positions;
+  std::vector< CoordinateVector<> > _discrete_positions;
   /*! @brief Weights of the discrete photon sources. */
-  std::vector< double > _weights;
+  std::vector< double > _discrete_weights;
 
-  /*! @brief Total luminosity of all sources together (in s^-1). */
-  double _total_luminosity;
+  /*! @brief Total luminosity of all discrete sources together (in s^-1). */
+  double _discrete_total_luminosity;
 
   /*! @brief Spectrum of the discrete photon sources. */
-  PhotonSourceSpectrum &_spectrum;
+  PhotonSourceSpectrum &_discrete_spectrum;
+
+  ///
+
+  /// continuous sources
+
+  /*! @brief Total number of photons emitted by the continuous sources. */
+  unsigned int _continuous_number_of_photons;
+
+  /*! @brief Number of photons emitted by the continuous sources. */
+  unsigned int _continuous_active_number_of_photons;
+
+  /*! @brief Spectrum of the continuous sources. */
+  PhotonSourceSpectrum *_continous_spectrum;
+
+  ///
 
   /*! @brief Cross sections for photoionization. */
   CrossSections &_cross_sections;
@@ -95,7 +112,7 @@ private:
 
 public:
   PhotonSource(PhotonSourceDistribution &distribution,
-               PhotonSourceSpectrum &spectrum, CrossSections &_cross_sections,
+               PhotonSourceSpectrum &spectrum, CrossSections &cross_sections,
                RandomGenerator &random_generator, Log *log = nullptr);
 
   unsigned int set_number_of_photons(unsigned int number_of_photons);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -494,8 +494,7 @@ set(TESTBLOCKSYNTAXDENSITYFUNCTION_SOURCES
     ../src/ParameterFile.hpp
 )
 add_unit_test(NAME testBlockSyntaxDensityFunction
-              SOURCES ${TESTBLOCKSYNTAXDENSITYFUNCTION_SOURCES}
-              LIBS ${HDF5_LIBRARIES})
+              SOURCES ${TESTBLOCKSYNTAXDENSITYFUNCTION_SOURCES})
 configure_file(${PROJECT_SOURCE_DIR}/test/blocksyntaxtest.yml
                ${PROJECT_BINARY_DIR}/rundir/test/blocksyntaxtest.yml
                COPYONLY)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -488,11 +488,14 @@ set(TESTBLOCKSYNTAXDENSITYFUNCTION_SOURCES
 
     ../src/BlockSyntaxBlock.hpp
     ../src/BlockSyntaxDensityFunction.hpp
+    ../src/CartesianDensityGrid.cpp
+    ../src/CartesianDensityGrid.hpp
     ../src/ParameterFile.cpp
     ../src/ParameterFile.hpp
 )
 add_unit_test(NAME testBlockSyntaxDensityFunction
-              SOURCES ${TESTBLOCKSYNTAXDENSITYFUNCTION_SOURCES})
+              SOURCES ${TESTBLOCKSYNTAXDENSITYFUNCTION_SOURCES}
+              LIBS ${HDF5_LIBRARIES})
 configure_file(${PROJECT_SOURCE_DIR}/test/blocksyntaxtest.yml
                ${PROJECT_BINARY_DIR}/rundir/test/blocksyntaxtest.yml
                COPYONLY)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -473,6 +473,15 @@ set(TESTOPACITYAMRREFINEMENTSCHEME_SOURCES
 add_unit_test(NAME testOpacityAMRRefinementScheme
               SOURCES ${TESTOPACITYAMRREFINEMENTSCHEME_SOURCES})
 
+## Unit test for IsotropicContinuousPhotonSource
+set(TESTISOTROPICCONTINUOUSPHOTONSOURCE_SOURCES
+    testIsotropicContinuousPhotonSource.cpp
+
+    ../src/IsotropicContinuousPhotonSource.hpp
+)
+add_unit_test(NAME testIsotropicContinuousPhotonSource
+              SOURCES ${TESTISOTROPICCONTINUOUSPHOTONSOURCE_SOURCES})
+
 ### Done adding unit tests. Create the 'make check' target #####################
 ### Do not touch these lines unless you know what you're doing! ################
 add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -482,6 +482,21 @@ set(TESTISOTROPICCONTINUOUSPHOTONSOURCE_SOURCES
 add_unit_test(NAME testIsotropicContinuousPhotonSource
               SOURCES ${TESTISOTROPICCONTINUOUSPHOTONSOURCE_SOURCES})
 
+## Unit test for BlockSyntaxDensityFunction
+set(TESTBLOCKSYNTAXDENSITYFUNCTION_SOURCES
+    testBlockSyntaxDensityFunction.cpp
+
+    ../src/BlockSyntaxBlock.hpp
+    ../src/BlockSyntaxDensityFunction.hpp
+    ../src/ParameterFile.cpp
+    ../src/ParameterFile.hpp
+)
+add_unit_test(NAME testBlockSyntaxDensityFunction
+              SOURCES ${TESTBLOCKSYNTAXDENSITYFUNCTION_SOURCES})
+configure_file(${PROJECT_SOURCE_DIR}/test/blocksyntaxtest.yml
+               ${PROJECT_BINARY_DIR}/rundir/test/blocksyntaxtest.yml
+               COPYONLY)
+
 ### Done adding unit tests. Create the 'make check' target #####################
 ### Do not touch these lines unless you know what you're doing! ################
 add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure

--- a/test/blocksyntaxtest.yml
+++ b/test/blocksyntaxtest.yml
@@ -1,7 +1,25 @@
-number of blocks: 1
+number of blocks: 4
 
 block[0]:
   origin: [0.5 m, 0.5 m, 0.5 m]
   sides: [1. m, 1. m, 1. m]
   type: cube
   number density: 0. m^-3
+
+block[1]:
+  origin: [0.5 m, 0.5 m, 0.5 m]
+  sides: [0.5 m, 0.5 m, 0.5 m]
+  type: sphere
+  number density: 1. m^-3
+
+block[2]:
+  origin: [0.5 m, 0.5 m, 0.5 m]
+  sides: [0.25 m, 0.25 m, 0.25 m]
+  type: sphere
+  number density: 2. m^-3
+
+block[3]:
+  origin: [0.25 m, 0.25 m, 0.25 m]
+  sides: [0.25 m, 0.25 m, 0.25 m]
+  type: rhombus
+  number density: 1. m^-3

--- a/test/blocksyntaxtest.yml
+++ b/test/blocksyntaxtest.yml
@@ -1,0 +1,7 @@
+number of blocks: 1
+
+block[0]:
+  origin: [0.5 m, 0.5 m, 0.5 m]
+  sides: [1. m, 1. m, 1. m]
+  type: cube
+  number density: 0. m^-3

--- a/test/testBlockSyntaxDensityFunction.cpp
+++ b/test/testBlockSyntaxDensityFunction.cpp
@@ -25,6 +25,7 @@
  */
 #include "Assert.hpp"
 #include "BlockSyntaxDensityFunction.hpp"
+#include "CartesianDensityGrid.hpp"
 
 /**
  * @brief Unit test for the BlockSyntaxDensityFunction class.
@@ -36,7 +37,15 @@
 int main(int argc, char **argv) {
   BlockSyntaxDensityFunction density_function("blocksyntaxtest.yml");
 
-  assert_condition(density_function(CoordinateVector<>(0.5)) == 0.);
+  CoordinateVector<> anchor;
+  CoordinateVector<> sides(1., 1., 1.);
+  Box box(anchor, sides);
+  CartesianDensityGrid grid(box, 64, 0., 8000., density_function);
+  assert_values_equal_tol(grid.get_total_hydrogen_number(),
+                          4. * M_PI * 0.25 * 0.25 * 0.25 / 3 +
+                              4. * M_PI * 0.125 * 0.125 * 0.125 / 3. +
+                              4. * 0.125 * 0.125 * 0.125 / 3.,
+                          0.1);
 
   return 0;
 }

--- a/test/testBlockSyntaxDensityFunction.cpp
+++ b/test/testBlockSyntaxDensityFunction.cpp
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * This file is part of CMacIonize
+ * Copyright (C) 2016 Bert Vandenbroucke (bert.vandenbroucke@gmail.com)
+ *
+ * CMacIonize is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CMacIonize is distributed in the hope that it will be useful,
+ * but WITOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with CMacIonize. If not, see <http://www.gnu.org/licenses/>.
+ ******************************************************************************/
+
+/**
+ * @file testBlockSyntaxDensityFunction.cpp
+ *
+ * @brief Unit test for the BlockSyntaxDensityFunction class.
+ *
+ * @author Bert Vandenbroucke (bv7@st-andrews.ac.uk)
+ */
+#include "Assert.hpp"
+#include "BlockSyntaxDensityFunction.hpp"
+
+/**
+ * @brief Unit test for the BlockSyntaxDensityFunction class.
+ *
+ * @param argc Number of command line arguments.
+ * @param argv Command line arguments.
+ * @return Exit code: 0 on success.
+ */
+int main(int argc, char **argv) {
+  BlockSyntaxDensityFunction density_function("blocksyntaxtest.yml");
+
+  assert_condition(density_function(CoordinateVector<>(0.5)) == 0.);
+
+  return 0;
+}

--- a/test/testIsotropicContinuousPhotonSource.cpp
+++ b/test/testIsotropicContinuousPhotonSource.cpp
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ * This file is part of CMacIonize
+ * Copyright (C) 2016 Bert Vandenbroucke (bert.vandenbroucke@gmail.com)
+ *
+ * CMacIonize is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CMacIonize is distributed in the hope that it will be useful,
+ * but WITOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with CMacIonize. If not, see <http://www.gnu.org/licenses/>.
+ ******************************************************************************/
+
+/**
+ * @file testIsotropicContinuousPhotonSource.cpp
+ *
+ * @brief Unit test for the IsotropicContinuousPhotonSource class.
+ *
+ * @author Bert Vandenbroucke (bv7@st-andrews.ac.uk)
+ */
+#include "Assert.hpp"
+#include "IsotropicContinuousPhotonSource.hpp"
+#include "RandomGenerator.hpp"
+#include <fstream>
+
+/**
+ * @brief Unit test for the IsotropicContinuousPhotonSource class.
+ *
+ * @param argc Number of command line arguments.
+ * @param argv Command line arguments.
+ * @return Exit code: 0 on success.
+ */
+int main(int argc, char **argv) {
+  Box box(CoordinateVector<>(), CoordinateVector<>(1.));
+  RandomGenerator random_generator(42);
+  IsotropicContinuousPhotonSource source(box, random_generator);
+
+  const unsigned int numphoton = 10000000;
+
+  unsigned int bins[6][101];
+  for (unsigned int i = 0; i < 6; ++i) {
+    for (unsigned int j = 0; j < 101; ++j) {
+      bins[i][j] = 0;
+    }
+  }
+
+  CoordinateVector<> average_position;
+  CoordinateVector<> average_direction;
+  for (unsigned int i = 0; i < numphoton; ++i) {
+    std::pair< CoordinateVector<>, CoordinateVector<> > posdir =
+        source.get_random_incoming_direction();
+    average_position += posdir.first;
+    average_direction += posdir.second;
+
+    for (unsigned int ip = 0; ip < 3; ++ip) {
+      unsigned int ibin = 100 * posdir.first[ip];
+      ++bins[ip][ibin];
+    }
+    for (unsigned int id = 0; id < 3; ++id) {
+      unsigned int ibin = 50 * (posdir.second[id] + 1.);
+      ++bins[id + 3][ibin];
+    }
+  }
+  average_position /= numphoton;
+  average_direction /= numphoton;
+
+  std::ofstream ofile("isotropic_bins.txt");
+  unsigned int binsum[6] = {0};
+  for (unsigned int i = 0; i < 101; ++i) {
+    ofile << i;
+    for (unsigned int j = 0; j < 6; ++j) {
+      ofile << "\t" << bins[j][i];
+      binsum[j] += bins[j][i];
+    }
+    ofile << "\n";
+  }
+
+  return 0;
+}


### PR DESCRIPTION
Added a new BlockSyntaxDensityFunction that constructs a density field using geometrical blocks read from a YAML file (similar to the BlockICGenerator used by Shadowfax, and the initial condition specification format for RAMSES).

This was actually pretty simple, as the YAML file can be read in as a ParameterFile.