### PR TITLE
External source

### DIFF
--- a/src/CMacIonize.cpp
+++ b/src/CMacIonize.cpp
@@ -33,6 +33,7 @@
 #include "DensityGridWriterFactory.hpp"
 #include "FileLog.hpp"
 #include "IonizationStateCalculator.hpp"
+#include "IsotropicContinuousPhotonSource.hpp"
 #include "IterationConvergenceCheckerFactory.hpp"
 #include "LineCoolingData.hpp"
 #include "ParameterFile.hpp"
@@ -133,8 +134,17 @@ int main(int argc, char **argv) {
       PhotonSourceDistributionFactory::generate(params, log);
   RandomGenerator random_generator(params.get_value< int >("random_seed", 42));
   PlanckPhotonSourceSpectrum spectrum(random_generator);
-  PhotonSource source(*sourcedistribution, spectrum, cross_sections,
-                      random_generator, log);
+  PhotonSource source(sourcedistribution, &spectrum, nullptr, nullptr, 1.,
+                      cross_sections, random_generator, log);
+
+  // external radiation test. Does not work (yet).
+  //  IsotropicContinuousPhotonSource isotropic_source(
+  //        Box(params.get_physical_vector<QUANTITY_LENGTH>("densitygrid.box_anchor"),
+  //            params.get_physical_vector<QUANTITY_LENGTH>("densitygrid.box_sides")),
+  //        random_generator);
+  //  PhotonSource source(nullptr, nullptr, &isotropic_source, &spectrum, 0.,
+  //  cross_sections,
+  //                      random_generator, log);
 
   // set up output
   DensityGridWriter *writer =

--- a/src/CMacIonizeSnapshotDensityFunction.cpp
+++ b/src/CMacIonizeSnapshotDensityFunction.cpp
@@ -1,0 +1,144 @@
+/*******************************************************************************
+ * This file is part of CMacIonize
+ * Copyright (C) 2016 Bert Vandenbroucke (bert.vandenbroucke@gmail.com)
+ *
+ * CMacIonize is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CMacIonize is distributed in the hope that it will be useful,
+ * but WITOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with CMacIonize. If not, see <http://www.gnu.org/licenses/>.
+ ******************************************************************************/
+
+/**
+ * @file CMacIonizeSnapshotDensityFunction.cpp
+ *
+ * @brief CMacIonizeSnapshotDensityFunction implementation.
+ *
+ * @author Bert Vandenbroucke (bv7@st-andrews.ac.uk)
+ */
+#include "CMacIonizeSnapshotDensityFunction.hpp"
+#include "HDF5Tools.hpp"
+#include "Log.hpp"
+#include "ParameterFile.hpp"
+
+/**
+ * @brief Constructor.
+ *
+ * @param filename Name of the snapshot file to read.
+ * @param log Log to write logging info to.
+ */
+CMacIonizeSnapshotDensityFunction::CMacIonizeSnapshotDensityFunction(
+    std::string filename, Log *log) {
+  HDF5Tools::HDF5File file =
+      HDF5Tools::open_file(filename, HDF5Tools::HDF5FILEMODE_READ);
+
+  // read grid parameters
+  HDF5Tools::HDF5Group group = HDF5Tools::open_group(file, "/Parameters");
+  std::vector< std::string > parameternames =
+      HDF5Tools::get_attribute_names(group);
+  ParameterFile parameters;
+  for (auto it = parameternames.begin(); it != parameternames.end(); ++it) {
+    std::string attname = *it;
+    std::string attvalue =
+        HDF5Tools::read_attribute< std::string >(group, attname);
+    parameters.add_value(attname, attvalue);
+  }
+  _box = Box(parameters.get_physical_vector< QUANTITY_LENGTH >(
+                 "densitygrid.box_anchor"),
+             parameters.get_physical_vector< QUANTITY_LENGTH >(
+                 "densitygrid.box_sides"));
+  _ncell = parameters.get_value< CoordinateVector< int > >("densitygrid.ncell");
+  HDF5Tools::close_group(group);
+
+  // read cell midpoints and densities
+  group = HDF5Tools::open_group(file, "/PartType0");
+  std::vector< CoordinateVector<> > cell_midpoints =
+      HDF5Tools::read_dataset< CoordinateVector<> >(group, "Coordinates");
+  std::vector< double > cell_densities =
+      HDF5Tools::read_dataset< double >(group, "NumberDensity");
+  HDF5Tools::close_group(group);
+
+  HDF5Tools::close_file(file);
+
+  if (log) {
+    log->write_status(
+        "Constructing a CMacIonizeSnapshotDensityFunction containing ",
+        _ncell.x(), " x ", _ncell.y(), " x ", _ncell.z(), " cells.");
+  }
+
+  _grid = new double **[_ncell.x()];
+  for (int ix = 0; ix < _ncell.x(); ++ix) {
+    _grid[ix] = new double *[_ncell.y()];
+    for (int iy = 0; iy < _ncell.y(); ++iy) {
+      _grid[ix][iy] = new double[_ncell.z()];
+      for (int iz = 0; iz < _ncell.z(); ++iz) {
+        _grid[ix][iy][iz] = -1.;
+      }
+    }
+  }
+
+  for (unsigned int i = 0; i < cell_midpoints.size(); ++i) {
+    CoordinateVector<> p = cell_midpoints[i];
+    // the anchor of the box is always [0., 0., 0.] in the snapshot file
+    int ix = _ncell.x() * p.x() / _box.get_sides().x();
+    int iy = _ncell.y() * p.y() / _box.get_sides().y();
+    int iz = _ncell.z() * p.z() / _box.get_sides().z();
+    _grid[ix][iy][iz] = cell_densities[i];
+  }
+
+  for (int ix = 0; ix < _ncell.x(); ++ix) {
+    for (int iy = 0; iy < _ncell.y(); ++iy) {
+      for (int iz = 0; iz < _ncell.z(); ++iz) {
+        if (_grid[ix][iy][iz] < 0.) {
+          error("No density value found for cell (%i, %i, %i)!", ix, iy, iz);
+        }
+      }
+    }
+  }
+}
+
+/**
+ * @brief ParameterFile constructor.
+ *
+ * @param params ParameterFile to read from.
+ * @param log Log to write logging info to.
+ */
+CMacIonizeSnapshotDensityFunction::CMacIonizeSnapshotDensityFunction(
+    ParameterFile &params, Log *log)
+    : CMacIonizeSnapshotDensityFunction(
+          params.get_value< std::string >("densityfunction.filename"), log) {}
+
+CMacIonizeSnapshotDensityFunction::~CMacIonizeSnapshotDensityFunction() {
+  for (int ix = 0; ix < _ncell.x(); ++ix) {
+    for (int iy = 0; iy < _ncell.y(); ++iy) {
+      delete[] _grid[ix][iy];
+    }
+    delete[] _grid[ix];
+  }
+  delete[] _grid;
+}
+
+/**
+ * @brief Get the density at the given position.
+ *
+ * @param position CoordinateVector specifying a position (in m).
+ * @return Density at that position (in m^-3).
+ */
+double CMacIonizeSnapshotDensityFunction::
+operator()(CoordinateVector<> position) {
+  // get the indices of the cell containing the position
+  int ix = _ncell.x() * (position.x() - _box.get_anchor().x()) /
+           _box.get_sides().x();
+  int iy = _ncell.y() * (position.y() - _box.get_anchor().y()) /
+           _box.get_sides().y();
+  int iz = _ncell.z() * (position.z() - _box.get_anchor().z()) /
+           _box.get_sides().z();
+  return _grid[ix][iy][iz];
+}

--- a/src/CMacIonizeSnapshotDensityFunction.hpp
+++ b/src/CMacIonizeSnapshotDensityFunction.hpp
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * This file is part of CMacIonize
+ * Copyright (C) 2016 Bert Vandenbroucke (bert.vandenbroucke@gmail.com)
+ *
+ * CMacIonize is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CMacIonize is distributed in the hope that it will be useful,
+ * but WITOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with CMacIonize. If not, see <http://www.gnu.org/licenses/>.
+ ******************************************************************************/
+
+/**
+ * @file CMacIonizeSnapshotDensityFunction.hpp
+ *
+ * @brief DensityFunction that reads a density grid from a CMacIonize snapshot.
+ *
+ * @author Bert Vandenbroucke (bv7@st-andrews.ac.uk)
+ */
+#ifndef CMACIONIZESNAPSHOTDENSITYFUNCTION_HPP
+#define CMACIONIZESNAPSHOTDENSITYFUNCTION_HPP
+
+#include "Box.hpp"
+#include "DensityFunction.hpp"
+
+class Log;
+class ParameterFile;
+
+/**
+ * @brief DensityFunction that reads a density grid from a CMacIonize snapshot.
+ */
+class CMacIonizeSnapshotDensityFunction : public DensityFunction {
+private:
+  /*! @brief Box containing the grid. */
+  Box _box;
+
+  /*! @brief Number of cells in each dimension. */
+  CoordinateVector< int > _ncell;
+
+  /*! @brief Density grid. */
+  double ***_grid;
+
+public:
+  CMacIonizeSnapshotDensityFunction(std::string filename, Log *log = nullptr);
+
+  CMacIonizeSnapshotDensityFunction(ParameterFile &params, Log *log = nullptr);
+
+  virtual ~CMacIonizeSnapshotDensityFunction();
+
+  virtual double operator()(CoordinateVector<> position);
+};
+
+#endif // CMACIONIZESNAPSHOTDENSITYFUNCTION_HPP

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -66,6 +66,7 @@ set(CMACIONIZE_SOURCES
     AsciiFileDensityFunction.cpp
     CartesianDensityGrid.cpp
     CMacIonize.cpp
+    CMacIonizeSnapshotDensityFunction.cpp
     CommandLineOption.cpp
     CommandLineParser.cpp
     CompilerInfo.cpp.in
@@ -87,6 +88,7 @@ set(CMACIONIZE_SOURCES
     CartesianDensityGrid.hpp
     ChiSquaredIterationConvergenceChecker.hpp
     ChiSquaredPhotonNumberConvergenceChecker.hpp
+    CMacIonizeSnapshotDensityFunction.hpp
     Configuration.hpp.in
     ContinuousPhotonSourceFactory.hpp
     CoordinateVector.hpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -88,6 +88,7 @@ set(CMACIONIZE_SOURCES
     ChiSquaredIterationConvergenceChecker.hpp
     ChiSquaredPhotonNumberConvergenceChecker.hpp
     Configuration.hpp.in
+    ContinuousPhotonSourceFactory.hpp
     CoordinateVector.hpp
     CommandLineOption.hpp
     CommandLineParser.hpp

--- a/src/CartesianDensityGrid.cpp
+++ b/src/CartesianDensityGrid.cpp
@@ -428,8 +428,10 @@ bool CartesianDensityGrid::interact(Photon &photon, double optical_depth) {
   // find out in which cell the photon is currently hiding
   CoordinateVector< int > index = get_cell_indices(photon_origin);
 
+  unsigned int ncell = 0;
   // while the photon has not exceeded the optical depth and is still in the box
   while (is_inside(index, photon_origin) && optical_depth > 0.) {
+    ++ncell;
     Box cell = get_cell(index);
 
     double ds;
@@ -471,6 +473,13 @@ bool CartesianDensityGrid::interact(Photon &photon, double optical_depth) {
     update_integrals(ds, density, photon);
 
     S += ds;
+  }
+
+  if (ncell == 0) {
+    error("Photon leaves the system immediately (position: %g %g %g, "
+          "direction: %g %g %g)!",
+          photon_origin.x(), photon_origin.y(), photon_origin.z(),
+          photon_direction.x(), photon_direction.y(), photon_direction.z());
   }
 
   photon.set_position(photon_origin);

--- a/src/ChiSquaredIterationConvergenceChecker.hpp
+++ b/src/ChiSquaredIterationConvergenceChecker.hpp
@@ -106,6 +106,9 @@ public:
     // before the first iteration, it makes no sense to calculate a chi2 value
     if (_chi2 == 0.) {
       _chi2 = 1.;
+      // we need to make sure _chi2 == _old_chi2, since otherwise the first
+      // iteration will use a larger number of photons than requested
+      _old_chi2 = 1.;
       return false;
     }
     _old_chi2 = _chi2;

--- a/src/ContinuousPhotonSourceFactory.hpp
+++ b/src/ContinuousPhotonSourceFactory.hpp
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * This file is part of CMacIonize
+ * Copyright (C) 2016 Bert Vandenbroucke (bert.vandenbroucke@gmail.com)
+ *
+ * CMacIonize is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CMacIonize is distributed in the hope that it will be useful,
+ * but WITOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with CMacIonize. If not, see <http://www.gnu.org/licenses/>.
+ ******************************************************************************/
+
+/**
+ * @file ContinuousPhotonSourceFactory.hpp
+ *
+ * @brief Factory class for ContinuousPhotonSource instances (currently there
+ * is only one instance, and the factory is only used to either generate it, or
+ * return a nullptr).
+ *
+ * @author Bert Vandenbroucke (bv7@st-andrews.ac.uk)
+ */
+#ifndef CONTINUOUSPHOTONSOURCEFACTORY_HPP
+#define CONTINUOUSPHOTONSOURCEFACTORY_HPP
+
+#include "Log.hpp"
+#include "ParameterFile.hpp"
+
+// implementations
+#include "IsotropicContinuousPhotonSource.hpp"
+
+/**
+ * @brief Factory class for ContinuousPhotonSource instances (currently there
+ * is only one instance, and the factory is only used to either generate it, or
+ * return a nullptr).
+ */
+class ContinuousPhotonSourceFactory {
+public:
+  /**
+   * @brief Generate an IsotropicContinuousPhotonSource, or return a nullptr.
+   *
+   * @param params ParameterFile to read from.
+   * @param random_generator RandomGenerator.
+   * @param log Log to write logging info to.
+   * @return Pointer to a newly created IsotropicContinuousPhotonSource
+   * instance. Memory management for the pointer needs to be handled by the
+   * calling routine.
+   */
+  inline static IsotropicContinuousPhotonSource *
+  generate(ParameterFile &params, RandomGenerator &random_generator,
+           Log *log = nullptr) {
+    std::string type =
+        params.get_value< std::string >("continuousphotonsource.type", "None");
+    if (log) {
+      log->write_info("Requested ContinuousPhotonSource type: ", type, ".");
+    }
+    if (type == "Isotropic") {
+      return new IsotropicContinuousPhotonSource(params, random_generator, log);
+    } else if (type == "None") {
+      return nullptr;
+    } else {
+      error("Unknown ContinuousPhotonSource type: \"%s\".", type.c_str());
+      return nullptr;
+    }
+  }
+};
+
+#endif // CONTINUOUSPHOTONSOURCEFACTORY_HPP

--- a/src/DensityFunctionFactory.hpp
+++ b/src/DensityFunctionFactory.hpp
@@ -39,6 +39,7 @@
 
 // HDF5 dependent implementations
 #ifdef HAVE_HDF5
+#include "CMacIonizeSnapshotDensityFunction.hpp"
 #include "FLASHSnapshotDensityFunction.hpp"
 #include "GadgetSnapshotDensityFunction.hpp"
 #endif
@@ -58,7 +59,8 @@ public:
    * @param log Log to write logging info to.
    */
   static void check_hdf5(std::string type, Log *log = nullptr) {
-    if (type == "GadgetSnapshot" || type == "FLASHSnapshot") {
+    if (type == "CMacIonizeSnapshot" || type == "FLASHSnapshot" ||
+        type == "GadgetSnapshot") {
       if (log) {
         log->write_error("Cannot create an instance of ", type,
                          "DensityFunction, since the code was "
@@ -99,6 +101,8 @@ public:
     } else if (type == "Homogeneous") {
       return new HomogeneousDensityFunction(params, log);
 #ifdef HAVE_HDF5
+    } else if (type == "CMacIonizeSnapshot") {
+      return new CMacIonizeSnapshotDensityFunction(params, log);
     } else if (type == "FLASHSnapshot") {
       return new FLASHSnapshotDensityFunction(params, log);
     } else if (type == "GadgetSnapshot") {

--- a/src/DensityGrid.hpp
+++ b/src/DensityGrid.hpp
@@ -76,8 +76,10 @@ protected:
    */
   inline void update_integrals(const double ds, DensityValues &cell,
                                Photon &photon) {
-    cell.increase_mean_intensity_H(ds * photon.get_hydrogen_cross_section());
-    cell.increase_mean_intensity_He(ds * photon.get_helium_cross_section());
+    if (cell.get_total_density() > 0.) {
+      cell.increase_mean_intensity_H(ds * photon.get_hydrogen_cross_section());
+      cell.increase_mean_intensity_He(ds * photon.get_helium_cross_section());
+    }
   }
 
 protected:

--- a/src/HDF5Tools.hpp
+++ b/src/HDF5Tools.hpp
@@ -475,6 +475,40 @@ read_attribute< std::vector< double > >(hid_t group, std::string name) {
 }
 
 /**
+ * @brief Add an attribute name to the list. Function used by H5Aiterate.
+ *
+ * @param group HDF5Group handle to the group we are reading.
+ * @param c_name C-string name of the attribute.
+ * @param info Attribute info.
+ * @param data Extra data passed on to the function.
+ * @return Error code used by H5Aiterate; just zero in our case.
+ */
+inline herr_t add_attribute_name(hid_t group, const char *c_name,
+                                 const H5A_info_t *info, void *data) {
+  std::vector< std::string > &names = *((std::vector< std::string > *)data);
+  std::string name(c_name);
+  names.push_back(name);
+  return 0;
+}
+
+/**
+ * @brief Get the names of all the attributes of the given group.
+ *
+ * @param group HDF5Group handle to an open group.
+ * @return std::vector containing the names of all attributes in the group.
+ */
+inline std::vector< std::string > get_attribute_names(hid_t group) {
+  std::vector< std::string > names;
+  herr_t hdf5status = H5Aiterate(group, H5_INDEX_NAME, H5_ITER_INC, nullptr,
+                                 add_attribute_name, &names);
+  if (hdf5status < 0) {
+    error("Failed to read attribute names for group!");
+  }
+
+  return names;
+}
+
+/**
  * @brief Write the attribute with the given name to the given group.
  *
  * @param group HDF5Group handle to an open HDF5 group.

--- a/src/IonizationStateCalculator.cpp
+++ b/src/IonizationStateCalculator.cpp
@@ -85,8 +85,13 @@ void IonizationStateCalculator::calculate_ionization_state(unsigned int nphoton,
 
       // coolants. We don't do them for the moment...
     } else {
-      cell.set_neutral_fraction_H(1.);
-      cell.set_neutral_fraction_He(1.);
+      if (ntot > 0.) {
+        cell.set_neutral_fraction_H(1.);
+        cell.set_neutral_fraction_He(1.);
+      } else {
+        cell.set_neutral_fraction_H(0.);
+        cell.set_neutral_fraction_He(0.);
+      }
     }
   }
 }

--- a/src/IsotropicContinuousPhotonSource.hpp
+++ b/src/IsotropicContinuousPhotonSource.hpp
@@ -53,15 +53,19 @@ public:
   /**
    * @brief Constructor.
    *
-   * @param box Box in which the radiation enters.
+   * @param box Box in which the radiation enters (in m).
    * @param random_generator Random generator.
-   * @param luminosity Total luminosity of the radiation (in s^-1).
+   * @param flux Total flux of the radiation (in m^-2s^-1).
    * @param log Log to write logging info to.
    */
   IsotropicContinuousPhotonSource(Box box, RandomGenerator &random_generator,
-                                  double luminosity, Log *log = nullptr)
-      : _box(box), _random_generator(random_generator),
-        _luminosity(luminosity) {
+                                  double flux, Log *log = nullptr)
+      : _box(box), _random_generator(random_generator) {
+    double area = 2. * _box.get_sides().x() * _box.get_sides().y() +
+                  2. * _box.get_sides().x() * _box.get_sides().z() +
+                  2. * _box.get_sides().y() * _box.get_sides().z();
+    _luminosity = flux * area;
+
     if (log) {
       log->write_status(
           "Constructed IsotropicContinuousPhotonSource with total luminosity ",
@@ -85,8 +89,8 @@ public:
                 params.get_physical_vector< QUANTITY_LENGTH >(
                     "densitygrid.box_sides")),
             random_generator,
-            params.get_physical_value< QUANTITY_FREQUENCY >(
-                "continuousphotonsource.luminosity", "4.26e49 s^-1"),
+            params.get_physical_value< QUANTITY_FLUX >(
+                "continuousphotonsource.flux", "5700 cm^-2s^-1"),
             log) {}
 
   /**

--- a/src/ParameterFile.hpp
+++ b/src/ParameterFile.hpp
@@ -57,7 +57,24 @@ private:
   void strip_whitespace_line(std::string &line);
 
 public:
+  /**
+   * @brief Empty constructor.
+   */
+  ParameterFile() {}
+
   ParameterFile(std::string filename);
+
+  /**
+   * @brief Add the given value and key to the internal dictionary.
+   *
+   * If the key already exists, the existing value is replaced.
+   *
+   * @param key Key.
+   * @param value Value.
+   */
+  inline void add_value(std::string key, std::string value) {
+    _dictionary[key] = value;
+  }
 
   void print_contents(std::ostream &stream);
 

--- a/src/PhotonSource.cpp
+++ b/src/PhotonSource.cpp
@@ -114,8 +114,14 @@ PhotonSource::set_number_of_photons(unsigned int number_of_photons) {
   _discrete_number_of_photons = 0;
   _continuous_number_of_photons = 0;
 
+  // make sure we have at least 10 photons per discrete source
   if (number_of_photons * _discrete_fraction < 10 * _discrete_weights.size()) {
     number_of_photons = 10 * _discrete_weights.size() / _discrete_fraction;
+  }
+
+  // make sure we have at least 100 photons for the continuous sources
+  if (number_of_photons * (1. - _discrete_fraction) < 100) {
+    number_of_photons = 100 / (1. - _discrete_fraction);
   }
 
   while (number_of_photons !=

--- a/src/PhotonSource.cpp
+++ b/src/PhotonSource.cpp
@@ -120,7 +120,8 @@ PhotonSource::set_number_of_photons(unsigned int number_of_photons) {
   }
 
   // make sure we have at least 100 photons for the continuous sources
-  if (number_of_photons * (1. - _discrete_fraction) < 100) {
+  if (_discrete_fraction < 1. &&
+      number_of_photons * (1. - _discrete_fraction) < 100) {
     number_of_photons = 100 / (1. - _discrete_fraction);
   }
 

--- a/src/PhotonSource.cpp
+++ b/src/PhotonSource.cpp
@@ -28,6 +28,7 @@
 #include "DensityValues.hpp"
 #include "ElementNames.hpp"
 #include "Error.hpp"
+#include "IsotropicContinuousPhotonSource.hpp"
 #include "Log.hpp"
 #include "PhotonSourceDistribution.hpp"
 #include "PhotonSourceSpectrum.hpp"
@@ -40,36 +41,55 @@ using namespace std;
  *
  * @param distribution PhotonSourceDistribution giving the positions of the
  * discrete photon sources.
- * @param spectrum PhotonSourceSpectrum for the discrete photon sources.
+ * @param discrete_spectrum PhotonSourceSpectrum for the discrete photon
+ * sources.
+ * @param continuous_source IsotropicContinuousPhotonSource.
+ * @param continuous_spectrum PhotonSourceSpectrum for the continuous photon
+ * source.
+ * @param discrete_to_continuous_ratio Relative weight of discrete and
+ * continuous sources.
  * @param cross_sections Cross sections for photoionization.
  * @param random_generator RandomGenerator used to generate random numbers.
  * @param log Log to write logging info to.
  */
-PhotonSource::PhotonSource(PhotonSourceDistribution &distribution,
-                           PhotonSourceSpectrum &spectrum,
+PhotonSource::PhotonSource(PhotonSourceDistribution *distribution,
+                           PhotonSourceSpectrum *discrete_spectrum,
+                           IsotropicContinuousPhotonSource *continuous_source,
+                           PhotonSourceSpectrum *continuous_spectrum,
+                           double discrete_to_continuous_ratio,
                            CrossSections &cross_sections,
                            RandomGenerator &random_generator, Log *log)
-    : _discrete_number_of_photons(0), _discrete_spectrum(spectrum),
+    : _discrete_number_of_photons(0), _discrete_spectrum(discrete_spectrum),
+      _continuous_source(continuous_source),
+      _continuous_spectrum(continuous_spectrum),
+      _discrete_to_continuous_ratio(discrete_to_continuous_ratio),
       _cross_sections(cross_sections), _random_generator(random_generator),
       _HLyc_spectrum(cross_sections, random_generator),
       _HeLyc_spectrum(cross_sections, random_generator),
       _He2pc_spectrum(random_generator), _log(log) {
-  _discrete_positions.resize(distribution.get_number_of_sources());
-  _discrete_weights.resize(distribution.get_number_of_sources());
-  for (unsigned int i = 0; i < _discrete_positions.size(); ++i) {
-    _discrete_positions[i] = distribution.get_position(i);
-    _discrete_weights[i] = distribution.get_weight(i);
-  }
-  _discrete_total_luminosity = distribution.get_total_luminosity();
 
-  if (_log) {
-    _log->write_status("Constructed PhotonSource with ",
-                       _discrete_positions.size(), " positions and weights.");
+  if (distribution != nullptr) {
+    _discrete_positions.resize(distribution->get_number_of_sources());
+    _discrete_weights.resize(distribution->get_number_of_sources());
+    for (unsigned int i = 0; i < _discrete_positions.size(); ++i) {
+      _discrete_positions[i] = distribution->get_position(i);
+      _discrete_weights[i] = distribution->get_weight(i);
+    }
+    _discrete_total_luminosity = distribution->get_total_luminosity();
+
+    if (_log) {
+      _log->write_status("Constructed PhotonSource with ",
+                         _discrete_positions.size(), " positions and weights.");
+    }
+
+    _discrete_active_source_index = 0;
+    _discrete_active_photon_index = 0;
+    _discrete_active_number_of_photons = 0;
   }
 
-  _discrete_active_source_index = 0;
-  _discrete_active_photon_index = 0;
-  _discrete_active_number_of_photons = 0;
+  if (continuous_source != nullptr) {
+    _continuous_active_number_of_photons = 0;
+  }
 }
 
 /**
@@ -85,33 +105,56 @@ PhotonSource::PhotonSource(PhotonSourceDistribution &distribution,
 unsigned int
 PhotonSource::set_number_of_photons(unsigned int number_of_photons) {
   _discrete_number_of_photons = 0;
+  _continuous_number_of_photons = 0;
 
-  if (number_of_photons < 10 * _discrete_weights.size()) {
-    number_of_photons = 10 * _discrete_weights.size();
+  if (number_of_photons * _discrete_to_continuous_ratio <
+      10 * _discrete_weights.size()) {
+    number_of_photons =
+        10 * _discrete_weights.size() / _discrete_to_continuous_ratio;
   }
 
-  while (number_of_photons != _discrete_number_of_photons) {
+  while (number_of_photons !=
+         _discrete_number_of_photons + _continuous_number_of_photons) {
     _discrete_number_of_photons = 0;
+    _continuous_number_of_photons =
+        std::round((1. - _discrete_to_continuous_ratio) * number_of_photons);
     for (unsigned int i = 0; i < _discrete_weights.size(); ++i) {
       _discrete_number_of_photons +=
-          std::round(number_of_photons * _discrete_weights[i]);
+          std::round(number_of_photons * _discrete_to_continuous_ratio *
+                     _discrete_weights[i]);
     }
-    number_of_photons = _discrete_number_of_photons;
+    number_of_photons =
+        _discrete_number_of_photons + _continuous_number_of_photons;
   }
 
-  _discrete_number_of_photons = number_of_photons;
+  _discrete_number_of_photons =
+      std::round(number_of_photons * _discrete_to_continuous_ratio);
 
   _discrete_active_source_index = 0;
   _discrete_active_photon_index = 0;
-  _discrete_active_number_of_photons =
-      round(_discrete_number_of_photons * _discrete_weights[0]);
+  if (_discrete_weights.size() > 0) {
+    _discrete_active_number_of_photons =
+        std::round(_discrete_number_of_photons * _discrete_weights[0]);
+  } else {
+    _discrete_active_number_of_photons = 0;
+  }
+
+  _continuous_number_of_photons =
+      std::round((1. - _discrete_to_continuous_ratio) * number_of_photons);
+  if (_discrete_number_of_photons == 0) {
+    _continuous_active_number_of_photons = 0;
+  } else {
+    // disable continuous sources and first do discrete sources
+    _continuous_active_number_of_photons = _continuous_number_of_photons;
+  }
 
   if (_log) {
     _log->write_info("Number of photons for PhotonSource reset to ",
-                     _discrete_number_of_photons, ".");
+                     _discrete_number_of_photons, " discrete photons and ",
+                     _continuous_number_of_photons, " continuous photons.");
   }
 
-  return _discrete_number_of_photons;
+  return _discrete_number_of_photons + _continuous_number_of_photons;
 }
 
 /**
@@ -121,33 +164,26 @@ PhotonSource::set_number_of_photons(unsigned int number_of_photons) {
  * @return Photon.
  */
 Photon PhotonSource::get_random_photon() {
-  if (_discrete_active_source_index == _discrete_positions.size()) {
-    // we completed a cycle, reset the counters
-    _discrete_active_source_index = 0;
-    _discrete_active_photon_index = 0;
-    _discrete_active_number_of_photons =
-        round(_discrete_number_of_photons * _discrete_weights[0]);
+
+  CoordinateVector<> position, direction;
+  double energy;
+  // check if we have a continuous or a discrete source photon
+  if (_continuous_active_number_of_photons < _continuous_number_of_photons) {
+    std::pair< CoordinateVector<>, CoordinateVector<> > posdir =
+        _continuous_source->get_random_incoming_direction();
+    position = posdir.first;
+    direction = posdir.second;
+    energy = _continuous_spectrum->get_random_frequency();
+  } else {
+    position = _discrete_positions[_discrete_active_source_index];
+    direction = get_random_direction();
+    energy = _discrete_spectrum->get_random_frequency();
   }
 
-  CoordinateVector<> position =
-      _discrete_positions[_discrete_active_source_index];
-
-  CoordinateVector<> direction = get_random_direction();
-
-  double energy = _discrete_spectrum.get_random_frequency();
   double xsecH = _cross_sections.get_cross_section(ELEMENT_H, energy);
   double xsecHe = _cross_sections.get_cross_section(ELEMENT_He, energy);
 
-  ++_discrete_active_photon_index;
-  if (_discrete_active_photon_index == _discrete_active_number_of_photons) {
-    _discrete_active_photon_index = 0;
-    ++_discrete_active_source_index;
-    if (_discrete_active_source_index < _discrete_positions.size()) {
-      _discrete_active_number_of_photons =
-          round(_discrete_number_of_photons *
-                _discrete_weights[_discrete_active_source_index]);
-    }
-  }
+  update_indices();
 
   return Photon(position, direction, energy, xsecH, xsecHe);
 }

--- a/src/PhotonSource.hpp
+++ b/src/PhotonSource.hpp
@@ -72,9 +72,6 @@ private:
   /*! @brief Weights of the discrete photon sources. */
   std::vector< double > _discrete_weights;
 
-  /*! @brief Total luminosity of all discrete sources together (in s^-1). */
-  double _discrete_total_luminosity;
-
   /*! @brief Spectrum of the discrete photon sources. */
   PhotonSourceSpectrum *_discrete_spectrum;
 
@@ -96,8 +93,12 @@ private:
 
   ///
 
-  /*! @brief Relative weights of discrete and continuous sources. */
-  double _discrete_to_continuous_ratio;
+  /*! @brief Fraction of photons that is emitted by discrete sources. */
+  double _discrete_fraction;
+
+  /*! @brief Total luminosity of all sources (discrete + continuous) (in s^-1).
+   */
+  double _total_luminosity;
 
   /*! @brief Cross sections for photoionization. */
   CrossSections &_cross_sections;
@@ -167,7 +168,6 @@ public:
                PhotonSourceSpectrum *discrete_spectrum,
                IsotropicContinuousPhotonSource *continuous_source,
                PhotonSourceSpectrum *continuous_spectrum,
-               double discrete_to_continuous_ratio,
                CrossSections &cross_sections, RandomGenerator &random_generator,
                Log *log = nullptr);
 

--- a/src/PhotonSource.hpp
+++ b/src/PhotonSource.hpp
@@ -39,6 +39,7 @@
 
 class CrossSections;
 class DensityValues;
+class IsotropicContinuousPhotonSource;
 class Log;
 class PhotonSourceDistribution;
 class PhotonSourceSpectrum;
@@ -75,22 +76,28 @@ private:
   double _discrete_total_luminosity;
 
   /*! @brief Spectrum of the discrete photon sources. */
-  PhotonSourceSpectrum &_discrete_spectrum;
+  PhotonSourceSpectrum *_discrete_spectrum;
 
   ///
 
   /// continuous sources
 
-  /*! @brief Total number of photons emitted by the continuous sources. */
+  /*! @brief Total number of photons emitted by the continuous source. */
   unsigned int _continuous_number_of_photons;
 
-  /*! @brief Number of photons emitted by the continuous sources. */
+  /*! @brief Number of photons already emitted by the continuous source. */
   unsigned int _continuous_active_number_of_photons;
 
+  /*! @brief IsotropicContinuousPhotonSource instance used. */
+  IsotropicContinuousPhotonSource *_continuous_source;
+
   /*! @brief Spectrum of the continuous sources. */
-  PhotonSourceSpectrum *_continous_spectrum;
+  PhotonSourceSpectrum *_continuous_spectrum;
 
   ///
+
+  /*! @brief Relative weights of discrete and continuous sources. */
+  double _discrete_to_continuous_ratio;
 
   /*! @brief Cross sections for photoionization. */
   CrossSections &_cross_sections;
@@ -110,10 +117,59 @@ private:
   /*! @brief Log to write logging info to. */
   Log *_log;
 
+  /**
+   * @brief Update the internal counters that distribute the photon sampling
+   * over the various discrete and continuous sources.
+   */
+  inline void update_indices() {
+    if (_continuous_active_number_of_photons < _continuous_number_of_photons) {
+      ++_continuous_number_of_photons;
+      if (_continuous_active_number_of_photons ==
+          _continuous_number_of_photons) {
+        // we did all continuous sources and completed the cycle, reset the
+        // counters and start again with the discrete sources
+        _discrete_active_source_index = 0;
+        _discrete_active_photon_index = 0;
+        _discrete_active_number_of_photons =
+            std::round(_discrete_number_of_photons * _discrete_weights[0]);
+        // in case there are no discrete sources
+        if (_discrete_active_source_index == _discrete_positions.size()) {
+          _continuous_active_number_of_photons = 0;
+        }
+      }
+    } else {
+      ++_discrete_active_photon_index;
+      if (_discrete_active_photon_index == _discrete_active_number_of_photons) {
+        _discrete_active_photon_index = 0;
+        ++_discrete_active_source_index;
+        if (_discrete_active_source_index < _discrete_positions.size()) {
+          _discrete_active_number_of_photons =
+              std::round(_discrete_number_of_photons *
+                         _discrete_weights[_discrete_active_source_index]);
+        } else {
+          // we did all discrete sources, now do the continuous source
+          _continuous_active_number_of_photons = 0;
+          // in case there are no continuous sources
+          if (_continuous_active_number_of_photons ==
+              _continuous_number_of_photons) {
+            _discrete_active_source_index = 0;
+            _discrete_active_photon_index = 0;
+            _discrete_active_number_of_photons =
+                std::round(_discrete_number_of_photons * _discrete_weights[0]);
+          }
+        }
+      }
+    }
+  }
+
 public:
-  PhotonSource(PhotonSourceDistribution &distribution,
-               PhotonSourceSpectrum &spectrum, CrossSections &cross_sections,
-               RandomGenerator &random_generator, Log *log = nullptr);
+  PhotonSource(PhotonSourceDistribution *distribution,
+               PhotonSourceSpectrum *discrete_spectrum,
+               IsotropicContinuousPhotonSource *continuous_source,
+               PhotonSourceSpectrum *continuous_spectrum,
+               double discrete_to_continuous_ratio,
+               CrossSections &cross_sections, RandomGenerator &random_generator,
+               Log *log = nullptr);
 
   unsigned int set_number_of_photons(unsigned int number_of_photons);
 

--- a/src/PhotonSourceDistributionFactory.hpp
+++ b/src/PhotonSourceDistributionFactory.hpp
@@ -81,12 +81,14 @@ public:
     std::string type = params.get_value< std::string >(
         "photonsourcedistribution.type", "SingleStar");
     if (log) {
-      log->write_info("Requested PhotonSourceDistribution type: ", type);
+      log->write_info("Requested PhotonSourceDistribution type: ", type, ".");
     }
 #ifndef HAVE_HDF5
     check_hdf5(type, log);
 #endif
-    if (type == "SILCC") {
+    if (type == "None") {
+      return nullptr;
+    } else if (type == "SILCC") {
       return new SILCCPhotonSourceDistribution(params, log);
     } else if (type == "SingleStar") {
       return new SingleStarPhotonSourceDistribution(params, log);

--- a/src/UnitConverter.hpp
+++ b/src/UnitConverter.hpp
@@ -41,6 +41,7 @@
  */
 enum Quantity {
   QUANTITY_DENSITY,
+  QUANTITY_FLUX,
   QUANTITY_FREQUENCY,
   QUANTITY_LENGTH,
   QUANTITY_MASS,
@@ -136,6 +137,50 @@ inline double UnitConverter< QUANTITY_DENSITY >::to_unit(double value,
     return value * 1.e-3;
   } else {
     error("Unknown density unit: \"%s\".", unit.c_str());
+    return 0.;
+  }
+}
+
+/// QUANTITY_FLUX
+
+/**
+ * @brief UnitConverter::to_SI() specialization for a flux.
+ *
+ * @param value Flux value in strange units.
+ * @param unit Strange units.
+ * @return Flux value in per square metres per second.
+ */
+template <>
+inline double UnitConverter< QUANTITY_FLUX >::to_SI(double value,
+                                                    std::string unit) {
+  if (unit == "m^-2s^-1") {
+    // quantity is already in SI units
+    return value;
+  } else if (unit == "cm^-2s^-1") {
+    return value * 1.e4;
+  } else {
+    error("Unknown flux unit: \"%s\".", unit.c_str());
+    return 0.;
+  }
+}
+
+/**
+ * @brief UnitConverter::to_unit() specialization for a flux.
+ *
+ * @param value Flux value in per square metres per second.
+ * @param unit Strange units.
+ * @return Flux value in strange units.
+ */
+template <>
+inline double UnitConverter< QUANTITY_FLUX >::to_unit(double value,
+                                                      std::string unit) {
+  if (unit == "m^-2s^-1") {
+    // quantity is already in requested units
+    return value;
+  } else if (unit == "cm^-2s^-1") {
+    return value * 1.e-4;
+  } else {
+    error("Unknown flux unit: \"%s\".", unit.c_str());
     return 0.;
   }
 }

--- a/test/testGadgetSnapshotPhotonSourceDistribution.cpp
+++ b/test/testGadgetSnapshotPhotonSourceDistribution.cpp
@@ -74,7 +74,7 @@ int main(int argc, char **argv) {
   TestCrossSections cross_sections;
   TestPhotonSourceSpectrum spectrum;
   RandomGenerator random_generator;
-  PhotonSource source(&distribution, &spectrum, nullptr, nullptr, 1.,
+  PhotonSource source(&distribution, &spectrum, nullptr, nullptr,
                       cross_sections, random_generator);
 
   Photon photon = source.get_random_photon();

--- a/test/testGadgetSnapshotPhotonSourceDistribution.cpp
+++ b/test/testGadgetSnapshotPhotonSourceDistribution.cpp
@@ -74,7 +74,8 @@ int main(int argc, char **argv) {
   TestCrossSections cross_sections;
   TestPhotonSourceSpectrum spectrum;
   RandomGenerator random_generator;
-  PhotonSource source(distribution, spectrum, cross_sections, random_generator);
+  PhotonSource source(&distribution, &spectrum, nullptr, nullptr, 1.,
+                      cross_sections, random_generator);
 
   Photon photon = source.get_random_photon();
   assert_condition(photon.get_position().x() == 0.5);

--- a/test/testHDF5Tools.cpp
+++ b/test/testHDF5Tools.cpp
@@ -52,6 +52,10 @@ int main(int argc, char **argv) {
 
     HDF5Tools::HDF5Group group = HDF5Tools::open_group(file, "/HydroScheme");
 
+    std::vector< std::string > attnames = HDF5Tools::get_attribute_names(group);
+
+    assert_condition(attnames.size() == 15);
+
     assert_condition(group > 0);
 
     // test reading various types of attributes.

--- a/test/testIsotropicContinuousPhotonSource.cpp
+++ b/test/testIsotropicContinuousPhotonSource.cpp
@@ -28,6 +28,45 @@
 #include "RandomGenerator.hpp"
 #include <fstream>
 
+/*! @brief Number of angular bins. */
+#define NUMANGLEBIN 16
+
+/*! @brief Number of directional bins. */
+#define NUMDIRBIN 100
+
+/**
+ * @brief Get the intersection point of the line through the given point and
+ * with the given direction with the sphere surrounding the entire box.
+ *
+ * @param f Point on the line.
+ * @param d Direction of the line.
+ * @return Intersection point.
+ */
+CoordinateVector<> get_sphere_position(CoordinateVector<> f,
+                                       CoordinateVector<> d) {
+  const double R = 2.;
+  double R2 = R * R;
+  double ddotf = d.x() * f.x() + d.y() * f.y() + d.z() * f.z();
+  double f2 = f.norm2();
+
+  double disc = 4. * ddotf * ddotf - 4. * (f2 - R2);
+  double l1 = -ddotf + 0.5 * std::sqrt(disc);
+  double l2 = -ddotf - 0.5 * std::sqrt(disc);
+  double l;
+
+  assert_condition(l1 * l2 < 0.);
+
+  if (l1 < 0.) {
+    l = l1;
+  } else {
+    l = l2;
+  }
+
+  CoordinateVector<> i = f + l * d;
+  assert_values_equal(i.norm(), R);
+  return i;
+}
+
 /**
  * @brief Unit test for the IsotropicContinuousPhotonSource class.
  *
@@ -36,11 +75,13 @@
  * @return Exit code: 0 on success.
  */
 int main(int argc, char **argv) {
-  Box box(CoordinateVector<>(), CoordinateVector<>(1.));
-  RandomGenerator random_generator(42);
+  Box box(CoordinateVector<>(-0.5), CoordinateVector<>(1.));
+  RandomGenerator random_generator(44);
   IsotropicContinuousPhotonSource source(box, random_generator, 1.);
 
-  const unsigned int numphoton = 10000000;
+  // to see the angular dependence, this number should be a factor 100 larger
+  // but then the unit test takes too long to complete
+  const unsigned int numphoton = 1000000;
 
   unsigned int bins[6][101];
   for (unsigned int i = 0; i < 6; ++i) {
@@ -48,6 +89,14 @@ int main(int argc, char **argv) {
       bins[i][j] = 0;
     }
   }
+  double sbins[NUMANGLEBIN][NUMDIRBIN + 1];
+  for (unsigned int i = 0; i < NUMANGLEBIN; ++i) {
+    for (unsigned int j = 0; j < NUMDIRBIN + 1; ++j) {
+      sbins[i][j] = 0.;
+    }
+  }
+
+  std::ofstream sfile("isotropic_sphere.txt");
 
   CoordinateVector<> average_position;
   CoordinateVector<> average_direction;
@@ -57,8 +106,49 @@ int main(int argc, char **argv) {
     average_position += posdir.first;
     average_direction += posdir.second;
 
+    CoordinateVector<> spos = get_sphere_position(posdir.first, posdir.second);
+
+    // we make angular bins for all rays in a thin band around the equator
+    // plane
+    if (std::abs(spos.z()) < 0.2) {
+      // convert the position to a position on the unit sphere
+      spos *= 0.5;
+      assert_values_equal(spos.norm(), 1.);
+      // get the phi angle (assuming x = cos(phi) and y = sin(phi))
+      double phi = std::atan2(spos.y(), spos.x());
+      // phi lies in the range [-pi, pi]
+      // find the index of phi in the NUMANGLEBIN bins, starting with bin
+      // [ -pi-0.5*(2.*pi)/NUMANGLEBIN, -pi+0.5*(2.*pi)/NUMANGLEBIN [
+      int ibin = 0.5 * NUMANGLEBIN * (phi + M_PI + M_PI / NUMANGLEBIN) / M_PI;
+      assert_condition(ibin >= 0);
+      assert_condition(ibin <= NUMANGLEBIN);
+      // rebin to correct for offset
+      if (ibin >= NUMANGLEBIN) {
+        ibin -= NUMANGLEBIN;
+      }
+
+      // we now find the outgoing angle, relative to the bin angle
+      double phi_ref = -M_PI + (2. * M_PI * ibin) / NUMANGLEBIN;
+
+      double phi_out = std::atan2(posdir.second.y(), posdir.second.x());
+      // + pi, since we expect the outgoing angle to be opposite to the bin
+      // angle
+      phi_out -= phi_ref + M_PI;
+      if (phi_out < -M_PI) {
+        phi_out += 2. * M_PI;
+      }
+      if (phi_out >= M_PI) {
+        phi_out -= 2. * M_PI;
+      }
+      // we only bin between -1. and 1.
+      int jbin = 0.5 * NUMDIRBIN * (phi_out + 1.);
+      assert_condition(jbin >= 0);
+      assert_condition(jbin < NUMDIRBIN);
+      sbins[ibin][jbin] += 1.;
+    }
+
     for (unsigned int ip = 0; ip < 3; ++ip) {
-      unsigned int ibin = 100 * posdir.first[ip];
+      unsigned int ibin = 100 * (posdir.first[ip] + 0.5);
       ++bins[ip][ibin];
     }
     for (unsigned int id = 0; id < 3; ++id) {
@@ -78,6 +168,25 @@ int main(int argc, char **argv) {
       binsum[j] += bins[j][i];
     }
     ofile << "\n";
+  }
+
+  for (unsigned int i = 0; i < NUMANGLEBIN; ++i) {
+    assert_condition(sbins[i][NUMDIRBIN] == 0);
+    for (unsigned int j = 0; j < NUMDIRBIN; ++j) {
+      sbins[i][NUMDIRBIN] += sbins[i][j];
+    }
+    sbins[i][NUMDIRBIN] = 1. / sbins[i][NUMDIRBIN];
+    for (unsigned int j = 0; j < NUMDIRBIN; ++j) {
+      sbins[i][j] *= sbins[i][NUMDIRBIN];
+    }
+  }
+
+  for (unsigned int i = 0; i < NUMDIRBIN + 1; ++i) {
+    sfile << i;
+    for (unsigned int j = 0; j < NUMANGLEBIN; ++j) {
+      sfile << "\t" << sbins[j][i];
+    }
+    sfile << "\n";
   }
 
   return 0;

--- a/test/testIsotropicContinuousPhotonSource.cpp
+++ b/test/testIsotropicContinuousPhotonSource.cpp
@@ -38,7 +38,7 @@
 int main(int argc, char **argv) {
   Box box(CoordinateVector<>(), CoordinateVector<>(1.));
   RandomGenerator random_generator(42);
-  IsotropicContinuousPhotonSource source(box, random_generator);
+  IsotropicContinuousPhotonSource source(box, random_generator, 1.);
 
   const unsigned int numphoton = 10000000;
 

--- a/test/testPhotonSource.cpp
+++ b/test/testPhotonSource.cpp
@@ -81,7 +81,7 @@ int main(int argc, char **argv) {
   TestCrossSections cross_sections;
   RandomGenerator random_generator;
 
-  PhotonSource source(&distribution, &spectrum, nullptr, nullptr, 1.,
+  PhotonSource source(&distribution, &spectrum, nullptr, nullptr,
                       cross_sections, random_generator);
   source.set_number_of_photons(1000001);
 

--- a/test/testPhotonSource.cpp
+++ b/test/testPhotonSource.cpp
@@ -81,7 +81,8 @@ int main(int argc, char **argv) {
   TestCrossSections cross_sections;
   RandomGenerator random_generator;
 
-  PhotonSource source(distribution, spectrum, cross_sections, random_generator);
+  PhotonSource source(&distribution, &spectrum, nullptr, nullptr, 1.,
+                      cross_sections, random_generator);
   source.set_number_of_photons(1000001);
 
   // check if the returned position is what we expect it to be

--- a/test/testUnitConverter.cpp
+++ b/test/testUnitConverter.cpp
@@ -58,6 +58,16 @@ int main(int argc, char **argv) {
   // 1 g in a cubic centimetre is more than 1 kg in a cubic metre
   assert_condition(UnitConverter< QUANTITY_DENSITY >::to_SI(1, "g cm^-3") > 1.);
 
+  /// FLUX
+  assert_condition(UnitConverter< QUANTITY_FLUX >::convert(1., "m^-2s^-1",
+                                                           "m^-2s^-1") == 1.);
+
+  assert_condition(UnitConverter< QUANTITY_FLUX >::convert(1., "cm^-2s^-1",
+                                                           "cm^-2s^-1") == 1.);
+  // 1 photon per square centimetres per second is more than 1 photon per square
+  // metres per second
+  assert_condition(UnitConverter< QUANTITY_FLUX >::to_SI(1, "cm^-2s^-1") > 1.);
+
   /// FREQUENCY
   assert_condition(
       UnitConverter< QUANTITY_FREQUENCY >::convert(1., "s^-1", "s^-1") == 1.);


### PR DESCRIPTION
PhotonSource can now use an external source as well as the already existing discrete internal sources. The newly create IsotropicicContinuousPhotonSource can be used to model a background radiation field that is isotropic in space.

Also added CMacIonizeSnapshotDensityFunction, a DensityFunction that can be used to reinitialize the density grid from a previous run. This is especially useful when the density field is read in from an SPH snapshot, since finding neighbours to construct the density field can be computationally expensive.