### PR TITLE
Fixed bug in PhotonSource::update_indices

### DIFF
--- a/src/PhotonSource.hpp
+++ b/src/PhotonSource.hpp
@@ -137,7 +137,7 @@ private:
    */
   inline void update_indices() {
     if (_continuous_active_number_of_photons < _continuous_number_of_photons) {
-      ++_continuous_number_of_photons;
+      ++_continuous_active_number_of_photons;
       if (_continuous_active_number_of_photons ==
           _continuous_number_of_photons) {
         // we did all continuous sources and completed the cycle, reset the


### PR DESCRIPTION
When a continuous source was present, the wrong index value was updated, so that the discrete sources (if present) were only traversed once. This probably caused trouble with the dwarf galaxy simulations.