### PR TITLE
Fixed bug in CompilerInfo::is_dirty.

### DIFF
--- a/src/CompilerInfo.hpp
+++ b/src/CompilerInfo.hpp
@@ -27,6 +27,7 @@
 #define COMPILERINFO_HPP
 
 #include "Error.hpp"
+#include "Utilities.hpp"
 
 #include <sstream>
 #include <string>
@@ -110,8 +111,7 @@ public:
    */
   static inline bool is_dirty() {
     std::string git_version = get_git_version();
-    size_t check = git_version.rfind("dirty");
-    return check == (git_version.size() - 5);
+    return Utilities::string_ends_with(git_version, "dirty");
   }
 
   /**

--- a/src/Utilities.hpp
+++ b/src/Utilities.hpp
@@ -641,6 +641,23 @@ inline std::string human_readable_bytes(unsigned long bytes) {
   bytestream << bytefloat << " " << byte_unit(sizecount);
   return bytestream.str();
 }
+
+/**
+ * @brief Check if the given std::string ends with the given std::string.
+ *
+ * @param haystack std::string to search in.
+ * @param needle std::string to search.
+ * @return True if haystack contains needle at the end.
+ */
+inline bool string_ends_with(const std::string &haystack,
+                             const std::string &needle) {
+  if (needle.size() > haystack.size()) {
+    return false;
+  }
+  size_t check = haystack.rfind(needle);
+  // make sure we only flag needle at the end of the string
+  return (check == haystack.size() - needle.size());
+}
 }
 
 #endif // UTILITIES_HPP

--- a/test/testUtilities.cpp
+++ b/test/testUtilities.cpp
@@ -44,5 +44,20 @@ int main(int argc, char **argv) {
   bytes = 1253626623;
   assert_condition(Utilities::human_readable_bytes(bytes) == "1.17 GB");
 
+  std::string haystack;
+  std::string needle = "dirty";
+  haystack = "v0.1-dirty";
+  assert_condition(Utilities::string_ends_with(haystack, needle) == true);
+  haystack = "v0.1-eldkef";
+  assert_condition(Utilities::string_ends_with(haystack, needle) == false);
+  haystack = "v0.6";
+  assert_condition(Utilities::string_ends_with(haystack, needle) == false);
+  haystack = "v0.6.";
+  assert_condition(Utilities::string_ends_with(haystack, needle) == false);
+  haystack = "dirty";
+  assert_condition(Utilities::string_ends_with(haystack, needle) == true);
+  haystack = "dirty-adef22f";
+  assert_condition(Utilities::string_ends_with(haystack, needle) == false);
+
   return 0;
 }


### PR DESCRIPTION
The bug caused version strings shorter than 5 characters to be incorrectly flagged as dirty. This is particularly annoying as the version string for a stable release (e.g. v0.6) is shorter than 5 characters...

Will replace the current v0.6 tag with a new one which includes this commit.