### PR TITLE
Arch native

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -337,6 +337,11 @@ else(Boost_FOUND)
   add_configuration_option(HAVE_MULTIPRECISION False)
 endif(Boost_FOUND)
 
+# Check if we need to enable architecture specific CPU instructions
+if(ACTIVATE_ARCH_NATIVE)
+  add_compiler_flag("-march=native" OPTIONAL)
+endif(ACTIVATE_ARCH_NATIVE)
+
 # Check if we need to activate fast math
 if(ACTIVATE_FAST_MATH)
   message(STATUS "Activating Fast Math...")

--- a/src/Unit.hpp
+++ b/src/Unit.hpp
@@ -122,7 +122,7 @@ public:
    * @return Reference to the resulting Unit.
    */
   inline Unit &operator^=(int_fast32_t power) {
-    if (power > 0) {
+    if (power >= 0) {
       int_fast32_t i = 1;
       double value = _value;
       while (i < power) {

--- a/src/UnitConverter.hpp
+++ b/src/UnitConverter.hpp
@@ -359,7 +359,7 @@ public:
         ++pos2;
       }
       const std::string powstr = name.substr(pos1, pos2 - pos1);
-      const int_fast32_t power = strtod(powstr.c_str(), nullptr);
+      const int_fast32_t power = std::stoi(powstr.c_str());
       unit ^= power;
       if (pos2 == name.size()) {
         return unit;
@@ -393,7 +393,7 @@ public:
           ++pos2;
         }
         const std::string powstr = name.substr(pos1, pos2 - pos1);
-        const int_fast32_t power = strtod(powstr.c_str(), nullptr);
+        const int_fast32_t power = std::stoi(powstr.c_str());
         unit2 ^= power;
       }
       unit *= unit2;

--- a/test/testVoronoiDensityGrid.cpp
+++ b/test/testVoronoiDensityGrid.cpp
@@ -45,7 +45,7 @@ int main(int argc, char **argv) {
     Box<> box(CoordinateVector<>(0.), CoordinateVector<>(1.));
     UniformRandomVoronoiGeneratorDistribution *test_positions =
         new UniformRandomVoronoiGeneratorDistribution(box, 100, 42);
-    VoronoiDensityGrid grid(test_positions, box, "Old", 0, false, false,
+    VoronoiDensityGrid grid(test_positions, box, "Old", 0, false, false, false,
                             nullptr);
     std::pair< cellsize_t, cellsize_t > block =
         std::make_pair(0, grid.get_number_of_cells());
@@ -63,7 +63,7 @@ int main(int argc, char **argv) {
     UniformRegularVoronoiGeneratorDistribution *test_positions =
         new UniformRegularVoronoiGeneratorDistribution(
             box, CoordinateVector< uint_fast32_t >(5));
-    VoronoiDensityGrid grid(test_positions, box, "Old", 0, false, false,
+    VoronoiDensityGrid grid(test_positions, box, "Old", 0, false, false, false,
                             nullptr);
     std::pair< cellsize_t, cellsize_t > block =
         std::make_pair(0, grid.get_number_of_cells());


### PR DESCRIPTION
## Description of the new code

Added the `-march=native` flag to the compilation command, which enables the use of hardware specific instructions and optimisations. When I tried to compile this with GCC 4.8.4, I got weird errors that seemed to be caused by wrong instructions. Since this is the default compiler on Ubuntu 14.04, I disabled the new option by default, it can be enabled by configuring with `-DACTIVATE_ARCH_NATIVE=True`. The new option works with GCC 7.3.0, and results in a speedup of ~5% for the Stromgren benchmark test.

While testing, I fixed some minor bugs.

## Impact of the new code

No code was changed except for some minor bug fixes. Unless you configure with the new option, the code should behave exactly the same as before.
