### PR TITLE
only files for mass accretion added

### DIFF
--- a/src/BlockSyntaxHydroMask.hpp
+++ b/src/BlockSyntaxHydroMask.hpp
@@ -93,7 +93,8 @@ public:
    *
    * @param grid DensityGrid to update.
    */
-  virtual void apply_mask(DensityGrid &grid) const {
+  virtual void apply_mask(DensityGrid &grid, double actual_timestep,
+                          double current_time) {
 
     const double hydrogen_mass =
         PhysicalConstants::get_physical_constant(PHYSICALCONSTANT_PROTON_MASS);

--- a/src/HydroMask.hpp
+++ b/src/HydroMask.hpp
@@ -53,8 +53,11 @@ public:
    * updated, all other cells are left untouched.
    *
    * @param grid DensityGrid to update.
+   * @param timestep
+   * @param current time of the simulation
    */
-  virtual void apply_mask(DensityGrid &grid) const = 0;
+  virtual void apply_mask(DensityGrid &grid, double actual_timestep,
+                          double current_time) = 0;
 };
 
 #endif // HYDROMASK_HPP

--- a/src/RadiationHydrodynamicsSimulation.cpp
+++ b/src/RadiationHydrodynamicsSimulation.cpp
@@ -348,7 +348,7 @@ int RadiationHydrodynamicsSimulation::do_simulation(CommandLineParser &parser,
   // apply the mask if applicable
   if (use_mask) {
     mask->initialize_mask(*grid);
-    mask->apply_mask(*grid);
+    mask->apply_mask(*grid, 0, 0);
   }
 
   if (write_output) {
@@ -461,7 +461,7 @@ int RadiationHydrodynamicsSimulation::do_simulation(CommandLineParser &parser,
 
     // apply the mask if applicable
     if (use_mask) {
-      mask->apply_mask(*grid);
+      mask->apply_mask(*grid, actual_timestep, current_time);
     }
 
     // update the PhotonSource

--- a/test/testBlockSyntaxHydroMask.cpp
+++ b/test/testBlockSyntaxHydroMask.cpp
@@ -53,7 +53,7 @@ int main(int argc, char **argv) {
   integrator.initialize_hydro_variables(grid);
 
   BlockSyntaxHydroMask hydro_mask("blocksyntaxtest.yml", gamma);
-  hydro_mask.apply_mask(grid);
+  hydro_mask.apply_mask(grid,0,0);
 
   std::ofstream ofile("test_hydro_mask.txt");
   ofile << "# x\ty\tz\trho\tux\tuy\tuz\tp\n";

--- a/test/testRescaledICHydroMask.cpp
+++ b/test/testRescaledICHydroMask.cpp
@@ -53,7 +53,7 @@ int main(int argc, char **argv) {
 
   RescaledICHydroMask hydro_mask(CoordinateVector<>(0.), 0.5, 0.01, 1., 0.02);
   hydro_mask.initialize_mask(grid);
-  hydro_mask.apply_mask(grid);
+  hydro_mask.apply_mask(grid,0,0);
 
   std::ofstream ofile("test_rescaled_hydro_mask.txt");
   ofile << "# x\ty\tz\trho\tux\tuy\tuz\tp\n";


### PR DESCRIPTION
## Description of the new code

The new code traces accretion rates through the mask outputing a .txt file with the accreted mass and position of each cell on the mask. The file also outputs the timestep and total simulation time until the moment it was produced. The frequency at which such files are produced is set through the variable delta t  within the HydroMask section of the parameter file (with default value as 5000 yr if no input provided).  

Modified files are
On src:
HydroMask.hpp
BolckSyntaxHydroMask.hpp
RadiationHydrodynamicsSimulation.cpp
RescaledICHydroMask.hpp

and the test files:

testBlockSyntaxHydroMask.cpp
testRescaledICHydroMask.cpp

## Impact of the new code

Tracing accretion through the mask is now possible, but modifications do not alter the general behaviour of the code.
