### PR TITLE
Self gravity

### DIFF
--- a/src/DensityGridWriterFields.hpp
+++ b/src/DensityGridWriterFields.hpp
@@ -58,6 +58,7 @@ enum DensityGridField {
   DENSITYGRIDFIELD_MASS,
   DENSITYGRIDFIELD_MOMENTUM,
   DENSITYGRIDFIELD_TOTAL_ENERGY,
+  DENSITYGRIDFIELD_ACCELERATION,
   DENSITYGRIDFIELD_NUMBER
 };
 
@@ -119,6 +120,8 @@ public:
       return DENSITYGRIDFIELDTYPE_VECTOR_DOUBLE;
     case DENSITYGRIDFIELD_TOTAL_ENERGY:
       return DENSITYGRIDFIELDTYPE_SCALAR_DOUBLE;
+    case DENSITYGRIDFIELD_ACCELERATION:
+      return DENSITYGRIDFIELDTYPE_VECTOR_DOUBLE;
     default:
       cmac_error("Unknown DensityGridField: %" PRIiFAST32, field_name);
       return DENSITYGRIDFIELDTYPE_NUMBER;
@@ -167,6 +170,8 @@ public:
       return "Momentum";
     case DENSITYGRIDFIELD_TOTAL_ENERGY:
       return "TotalEnergy";
+    case DENSITYGRIDFIELD_ACCELERATION:
+      return "Acceleration";
     default:
       cmac_error("Unknown DensityGridField: %" PRIiFAST32, field_name);
       return "";
@@ -219,6 +224,8 @@ public:
       return false;
     case DENSITYGRIDFIELD_TOTAL_ENERGY:
       return false;
+    case DENSITYGRIDFIELD_ACCELERATION:
+      return false;
     default:
       cmac_error("Unknown DensityGridField: %" PRIiFAST32, field_name);
       return false;
@@ -266,6 +273,8 @@ public:
     case DENSITYGRIDFIELD_MOMENTUM:
       return false;
     case DENSITYGRIDFIELD_TOTAL_ENERGY:
+      return false;
+    case DENSITYGRIDFIELD_ACCELERATION:
       return false;
     default:
       cmac_error("Unknown DensityGridField: %" PRIiFAST32, field_name);
@@ -315,6 +324,8 @@ public:
       return false;
     case DENSITYGRIDFIELD_TOTAL_ENERGY:
       return false;
+    case DENSITYGRIDFIELD_ACCELERATION:
+      return false;
     default:
       cmac_error("Unknown DensityGridField: %" PRIiFAST32, field_name);
       return false;
@@ -362,6 +373,8 @@ public:
     case DENSITYGRIDFIELD_MOMENTUM:
       return true;
     case DENSITYGRIDFIELD_TOTAL_ENERGY:
+      return true;
+    case DENSITYGRIDFIELD_ACCELERATION:
       return true;
     default:
       cmac_error("Unknown DensityGridField: %" PRIiFAST32, field_name);
@@ -458,6 +471,14 @@ public:
             it.get_hydro_variables().get_conserved_momentum());
       } else {
         return it.get_hydro_variables().get_conserved_momentum();
+      }
+    }
+    case DENSITYGRIDFIELD_ACCELERATION: {
+      if (hydro_units != nullptr) {
+        return hydro_units->convert_to_SI_units< QUANTITY_ACCELERATION >(
+            it.get_hydro_variables().get_gravitational_acceleration());
+      } else {
+        return it.get_hydro_variables().get_gravitational_acceleration();
       }
     }
     default:

--- a/src/MortonKeyGenerator.hpp
+++ b/src/MortonKeyGenerator.hpp
@@ -1,0 +1,115 @@
+/*******************************************************************************
+ * This file is part of CMacIonize
+ * Copyright (C) 2018 Bert Vandenbroucke (bert.vandenbroucke@gmail.com)
+ *
+ * CMacIonize is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CMacIonize is distributed in the hope that it will be useful,
+ * but WITOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with CMacIonize. If not, see <http://www.gnu.org/licenses/>.
+ ******************************************************************************/
+
+/**
+ * @file MortonKeyGenerator.hpp
+ *
+ * @brief Generator for Morton (z-order) keys.
+ *
+ * @author Bert Vandenbroucke (bv7@st-andrews.ac.uk)
+ */
+#ifndef MORTONKEYGENERATOR_HPP
+#define MORTONKEYGENERATOR_HPP
+
+#include "Box.hpp"
+
+/*! @brief Morton key type. */
+typedef uint64_t morton_key_t;
+
+/**
+ * @brief Generator for Morton space-filling keys.
+ */
+class MortonKeyGenerator {
+private:
+  /*! @brief All-encompassing box to use for coordinate to key conversions (in
+   *  m). */
+  const Box<> _box;
+
+public:
+  /**
+   * @brief Constructor.
+   *
+   * @param box All-encompassing box to use for coordinate to key conversions
+   * (in m).
+   */
+  inline MortonKeyGenerator(const Box<> &box) : _box(box) {}
+
+  /**
+   * @brief Get the Morton key for the given position.
+   *
+   * @param c Position.
+   * @return Corresponding Morton key.
+   */
+  inline morton_key_t get_key(const CoordinateVector<> &c) const {
+
+    // map the given coordinate onto the 21-bit coordinate space
+    const CoordinateVector< uint32_t > bits(
+        0x001fffff * (c.x() - _box.get_anchor().x()) / _box.get_sides().x(),
+        0x001fffff * (c.y() - _box.get_anchor().y()) / _box.get_sides().y(),
+        0x001fffff * (c.z() - _box.get_anchor().z()) / _box.get_sides().z());
+
+    // compute the key:
+    morton_key_t key = 0;
+    // bit mask for the current level. We can determine if the value of an
+    // integer coordinate is 0 or 1 by taking a bitwise AND with this mask and
+    // checking if it is larger than 0
+    // we start with the highest bit: bit 21
+    uint32_t mask = 0x00100000;
+    bool x[3];
+    // Morton key of the coordinates on the given level. This is just the 3-bit
+    // key with the highest bit being the x integer coordinate, the middle bit
+    // the y integer coordinate, and the lowest bit the z integer coordinate
+    uint_fast8_t ci;
+    // traverse all 21 bits of the integer coordinates to compute the key
+    for (uint_fast8_t i = 21; i > 0; --i) {
+      // first make space for the new part of the key by shifting the key by
+      // 3-bits. This has no effect for the first iteration.
+      key <<= 3;
+      // get the integer coordinates on this level (they are all either 0 or 1)
+      x[0] = (bits[0] & mask) > 0;
+      x[1] = (bits[1] & mask) > 0;
+      x[2] = (bits[2] & mask) > 0;
+      // compute the Morton key (since that is used in the lookup table)
+      ci = (x[0] << 2) | (x[1] << 1) | x[2];
+      // add the key component on this level
+      key += ci;
+      // shift the mask to the next (lower) bit of the coordinates
+      mask >>= 1;
+    }
+    return key;
+  }
+
+  /**
+   * @brief Get the Morton keys for all positions in the given vector.
+   *
+   * @param positions std::vector containing positions (in m).
+   * @return std::vector containing the corresponding Morton keys.
+   */
+  inline std::vector< morton_key_t >
+  get_keys(const std::vector< CoordinateVector<> > &positions) const {
+
+    const size_t positions_size = positions.size();
+    std::vector< morton_key_t > keys(positions_size, 0);
+    for (size_t i = 0; i < positions_size; ++i) {
+      keys[i] = get_key(positions[i]);
+    }
+    return keys;
+  }
+};
+
+#endif // MORTONKEYGENERATOR_HPP

--- a/src/TreeSelfGravity.hpp
+++ b/src/TreeSelfGravity.hpp
@@ -1,0 +1,364 @@
+/*******************************************************************************
+ * This file is part of CMacIonize
+ * Copyright (C) 2018 Bert Vandenbroucke (bert.vandenbroucke@gmail.com)
+ *
+ * CMacIonize is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CMacIonize is distributed in the hope that it will be useful,
+ * but WITOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with CMacIonize. If not, see <http://www.gnu.org/licenses/>.
+ ******************************************************************************/
+
+/**
+ * @file TreeSelfGravity.hpp
+ *
+ * @brief Tree algorithm to compute self-gravity for a DensityGrid.
+ *
+ * @author Bert Vandenbroucke (bv7@st-andrews.ac.uk)
+ */
+#ifndef TREESELFGRAVITY_HPP
+#define TREESELFGRAVITY_HPP
+
+#include "DensityGrid.hpp"
+#include "MortonKeyGenerator.hpp"
+#include "PhysicalConstants.hpp"
+
+/**
+ * @brief Tree algorithm to compute self-gravity for a DensityGrid.
+ */
+class TreeSelfGravity {
+private:
+  /**
+   * @brief General interface for both intermediate tree nodes and leaves.
+   */
+  class Node {
+  public:
+    /**
+     * @brief Virtual destructor.
+     */
+    virtual ~Node() {}
+
+    /**
+     * @brief Get the node type: intermediate node or leaf.
+     *
+     * @return Intermediate node (0) or leaf (1).
+     */
+    virtual unsigned char get_type() = 0;
+  };
+
+  /**
+   * @brief Leaf of the gravity tree.
+   */
+  class Leaf : public Node {
+  private:
+    /*! @brief Leaf position (in m). */
+    CoordinateVector<> _position;
+
+    /*! @brief Leaf mass (in kg). */
+    double _mass;
+
+    /*! @brief Key of the associated cell. */
+    morton_key_t _key;
+
+    /*! @brief Iterator to the associated cell. */
+    DensityGrid::iterator _cell;
+
+  public:
+    /**
+     * @brief Constructor.
+     *
+     * @param position Position of the leaf (in m).
+     * @param mass Mass of the leaf (in kg).
+     * @param key Morton key of the leaf.
+     * @param cell Iterator to the associated cell.
+     */
+    Leaf(const CoordinateVector<> position, const double mass,
+         const morton_key_t key, DensityGrid::iterator cell)
+        : _position(position), _mass(mass), _key(key), _cell(cell) {}
+
+    /**
+     * @brief Get the node type: intermediate node or leaf.
+     *
+     * @return Leaf (1).
+     */
+    virtual unsigned char get_type() { return 1; }
+
+    /**
+     * @brief Get the position of the leaf.
+     *
+     * @return Position (in m).
+     */
+    inline CoordinateVector<> get_position() const { return _position; }
+
+    /**
+     * @brief Get the mass of the leaf.
+     *
+     * @return Mass (in kg).
+     */
+    inline double get_mass() const { return _mass; }
+
+    /**
+     * @brief Get the Morton key of the leaf.
+     *
+     * @return Morton key.
+     */
+    inline morton_key_t get_key() const { return _key; }
+
+    /**
+     * @brief Get the cell of the leaf.
+     *
+     * @return Iterator to the associated cell.
+     */
+    inline DensityGrid::iterator get_cell() const { return _cell; }
+
+    /**
+     * @brief Update the mass of the leaf.
+     */
+    inline void update() {
+      _mass = _cell.get_hydro_variables().get_conserved_mass();
+    }
+  };
+
+  /**
+   * @brief Intermediate node of the gravity tree.
+   */
+  class TreeNode : public Node {
+  private:
+    /*! @brief Child nodes. */
+    Node *_children[8];
+
+    /*! @brief Box containing the node. */
+    Box<> _box;
+
+    /*! @brief Center of mass position (in m). */
+    CoordinateVector<> _COM_position;
+
+    /*! @brief Center of mass mass (in kg). */
+    double _COM_mass;
+
+  public:
+    /**
+     * @brief Intermediate node constructor.
+     *
+     * @param box Box containing the node.
+     */
+    TreeNode(const Box<> box) : _box(box) {
+      for (uint_fast8_t i = 0; i < 8; ++i) {
+        _children[i] = nullptr;
+      }
+    }
+
+    /**
+     * @brief Virtual destructor.
+     */
+    virtual ~TreeNode() {
+      for (uint_fast8_t i = 0; i < 8; ++i) {
+        delete _children[i];
+      }
+    }
+
+    /**
+     * @brief Get the node type: intermediate node or leaf.
+     *
+     * @return Intermediate node (0).
+     */
+    virtual unsigned char get_type() { return 0; }
+
+    /**
+     * @brief Add the given position to the node.
+     *
+     * @param position Position (in m).
+     * @param mass Mass (in kg).
+     * @param key Morton key.
+     * @param cell Iterator to the associated cell.
+     * @param level Current level in the tree.
+     */
+    inline void add_position(const CoordinateVector<> position,
+                             const double mass, const morton_key_t key,
+                             DensityGrid::iterator cell,
+                             const unsigned char level = 0) {
+
+      // get the bit of the Morton key corresponding to the current tree level
+      morton_key_t node_key = (key >> (60 - 3 * level)) & 7;
+
+      // check if the corresponding child is still available
+      if (_children[node_key] == nullptr) {
+        // it is: create a new leaf
+        _children[node_key] = new Leaf(position, mass, key, cell);
+      } else {
+        // it is not: check whether the existing child is a node or a leaf
+        if (_children[node_key]->get_type() == 0) {
+          // intermediate node: add to this node
+          static_cast< TreeNode * >(_children[node_key])
+              ->add_position(position, mass, key, cell, level + 1);
+        } else {
+          // it is: replace with a new intermediate node
+          Leaf *old_leaf = static_cast< Leaf * >(_children[node_key]);
+          CoordinateVector<> box_anchor = _box.get_anchor();
+          CoordinateVector<> box_sides = 0.5 * _box.get_sides();
+          if ((node_key & 4) > 0) {
+            box_anchor[0] += box_sides[0];
+          }
+          if ((node_key & 2) > 0) {
+            box_anchor[1] += box_sides[1];
+          }
+          if ((node_key & 1) > 0) {
+            box_anchor[2] += box_sides[2];
+          }
+          const Box<> box(box_anchor, box_sides);
+          _children[node_key] = new TreeNode(box);
+          static_cast< TreeNode * >(_children[node_key])
+              ->add_position(position, mass, key, cell, level + 1);
+          static_cast< TreeNode * >(_children[node_key])
+              ->add_position(old_leaf->get_position(), old_leaf->get_mass(),
+                             old_leaf->get_key(), old_leaf->get_cell(),
+                             level + 1);
+          delete old_leaf;
+        }
+      }
+    }
+
+    /**
+     * @brief Get the center of mass position of the node.
+     *
+     * @return Center of mass position (in m).
+     */
+    inline CoordinateVector<> get_COM_position() const { return _COM_position; }
+
+    /**
+     * @brief Get the center of mass mass of the node.
+     *
+     * @return Center of mass mass (in kg).
+     */
+    inline double get_COM_mass() const { return _COM_mass; }
+
+    /**
+     * @brief Get the width of the node.
+     *
+     * @return Width of the node (in m).
+     */
+    inline double get_node_width() const { return _box.get_sides().max(); }
+
+    /**
+     * @brief Compute the center of mass of the node (and all children).
+     */
+    inline void finalize() {
+      _COM_mass = 0.;
+      for (uint_fast8_t i = 0; i < 8; ++i) {
+        if (_children[i] != nullptr) {
+          if (_children[i]->get_type() == 0) {
+            TreeNode *child_node = static_cast< TreeNode * >(_children[i]);
+            child_node->finalize();
+            _COM_mass += child_node->get_COM_mass();
+            _COM_position +=
+                child_node->get_COM_mass() * child_node->get_COM_position();
+          } else {
+            Leaf *child_leaf = static_cast< Leaf * >(_children[i]);
+            child_leaf->update();
+            _COM_mass += child_leaf->get_mass();
+            _COM_position +=
+                child_leaf->get_mass() * child_leaf->get_position();
+          }
+        }
+      }
+      _COM_position /= _COM_mass;
+    }
+
+    /**
+     * @brief Get the gravitational acceleration at the given position.
+     *
+     * @param position Position (in m).
+     * @return Gravitational acceleration without Newton constant (in kg m^-2).
+     */
+    inline CoordinateVector<>
+    get_acceleration(const CoordinateVector<> position) const {
+      CoordinateVector<> a;
+      for (uint_fast8_t i = 0; i < 8; ++i) {
+        if (_children[i] != nullptr) {
+          if (_children[i]->get_type() == 0) {
+            const TreeNode *child_node =
+                static_cast< TreeNode * >(_children[i]);
+            // check if we need to open the node
+            const double width = child_node->get_node_width();
+            const CoordinateVector<> r =
+                child_node->get_COM_position() - position;
+            const double r2 = r.norm2();
+            if (width * width <= 0.25 * r2) {
+              // node is far enough away: don't open it
+              a += child_node->get_COM_mass() * r / (r2 * std::sqrt(r2));
+            } else {
+              a += child_node->get_acceleration(position);
+            }
+          } else {
+            const Leaf *child_leaf = static_cast< Leaf * >(_children[i]);
+            const CoordinateVector<> r = child_leaf->get_position() - position;
+            const double r2 = r.norm2();
+            if (r2 > 0.) {
+              a += child_leaf->get_mass() * r / (r2 * std::sqrt(r2));
+            }
+          }
+        }
+      }
+      return a;
+    }
+  };
+
+  /*! @brief Root node of the tree. */
+  TreeNode *_tree_root;
+
+public:
+  /**
+   * @brief Constructor.
+   *
+   * @param grid DensityGrid to operate on.
+   */
+  TreeSelfGravity(DensityGrid &grid) {
+
+    MortonKeyGenerator key_generator(grid.get_box());
+
+    _tree_root = new TreeNode(grid.get_box());
+    for (auto it = grid.begin(); it != grid.end(); ++it) {
+      const CoordinateVector<> position = it.get_cell_midpoint();
+      const double mass = it.get_hydro_variables().get_conserved_mass();
+      const morton_key_t key = key_generator.get_key(position);
+      _tree_root->add_position(position, mass, key, it);
+    }
+
+    _tree_root->finalize();
+  }
+
+  /**
+   * @brief Compute the accelerations for all cells in the grid.
+   *
+   * @param grid DensityGrid to operate on.
+   */
+  inline void compute_accelerations(DensityGrid &grid) {
+
+    // first make sure the tree is up to date
+    _tree_root->finalize();
+
+    const double G = PhysicalConstants::get_physical_constant(
+        PHYSICALCONSTANT_NEWTON_CONSTANT);
+    // now loop over the particles and compute the accelerations
+    for (auto it = grid.begin(); it != grid.end(); ++it) {
+      const CoordinateVector<> a_grav =
+          G * _tree_root->get_acceleration(it.get_cell_midpoint());
+      it.get_hydro_variables().set_gravitational_acceleration(
+          it.get_hydro_variables().get_gravitational_acceleration() + a_grav);
+    }
+  }
+
+  /**
+   * @brief Destructor.
+   */
+  ~TreeSelfGravity() { delete _tree_root; }
+};
+
+#endif // TREESELFGRAVITY_HPP

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1258,5 +1258,5 @@ endif(HAVE_PYTHON)
 
 ### Done adding unit tests. Create the 'make check' target #####################
 ### Do not touch these lines unless you know what you're doing! ################
-add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure -R testTreeSelfGravity
+add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure
                         DEPENDS ${TESTNAMES})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1191,6 +1191,26 @@ set(TESTINTERNALHYDROUNITS_SOURCES
 add_unit_test(NAME testInternalHydroUnits
               SOURCES ${TESTINTERNALHYDROUNITS_SOURCES})
 
+## Unit test for TreeSelfGravity
+set(TESTTREESELFGRAVITY_SOURCES
+    testTreeSelfGravity.cpp
+
+    ../src/CartesianDensityGrid.cpp
+    ../src/DensityGrid.cpp
+    ../src/TreeSelfGravity.hpp
+)
+add_unit_test(NAME testTreeSelfGravity
+              SOURCES ${TESTTREESELFGRAVITY_SOURCES})
+
+## Unit test for MortonKeyGenerator
+set(TESTMORTONKEYGENERATOR_SOURCES
+    testMortonKeyGenerator.cpp
+
+    ../src/MortonKeyGenerator.hpp
+)
+add_unit_test(NAME testMortonKeyGenerator
+              SOURCES ${TESTMORTONKEYGENERATOR_SOURCES})
+
 ### Python module unit tests ###################################################
 macro(add_python_unit_test)
     set(oneValueArgs NAME)
@@ -1238,5 +1258,5 @@ endif(HAVE_PYTHON)
 
 ### Done adding unit tests. Create the 'make check' target #####################
 ### Do not touch these lines unless you know what you're doing! ################
-add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure
+add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure -R testTreeSelfGravity
                         DEPENDS ${TESTNAMES})

--- a/test/testMortonKeyGenerator.cpp
+++ b/test/testMortonKeyGenerator.cpp
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * This file is part of CMacIonize
+ * Copyright (C) 2018 Bert Vandenbroucke (bert.vandenbroucke@gmail.com)
+ *
+ * CMacIonize is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CMacIonize is distributed in the hope that it will be useful,
+ * but WITOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with CMacIonize. If not, see <http://www.gnu.org/licenses/>.
+ ******************************************************************************/
+
+/**
+ * @file testMortonKeyGenerator.cpp
+ *
+ * @brief Unit test for the MortonKeyGenerator class.
+ *
+ * @author Bert Vandenbroucke (bv7@st-andrews.ac.uk)
+ */
+#include "Assert.hpp"
+#include "MortonKeyGenerator.hpp"
+#include "Utilities.hpp"
+#include <fstream>
+
+/**
+ * @brief Unit test for the MortonKeyGenerator class.
+ *
+ * @param argc Number of command line arguments.
+ * @param argv Command line arguments.
+ * @return Exit code: 0 on success.
+ */
+int main(int argc, char **argv) {
+
+  Box<> box(CoordinateVector<>(0.), CoordinateVector<>(1.));
+  MortonKeyGenerator key_generator(box);
+
+  std::vector< CoordinateVector<> > positions(64);
+  for (uint_fast8_t ix = 0; ix < 4; ++ix) {
+    for (uint_fast8_t iy = 0; iy < 4; ++iy) {
+      for (uint_fast8_t iz = 0; iz < 4; ++iz) {
+        positions[16 * ix + 4 * iy + iz] = CoordinateVector<>(
+            0.25 * (ix + 0.5), 0.25 * (iy + 0.5), 0.25 * (iz + 0.5));
+      }
+    }
+  }
+
+  std::vector< morton_key_t > keys = key_generator.get_keys(positions);
+  assert_condition(keys.size() == 64);
+
+  std::ofstream ofile("test_morton_curve.txt");
+  std::vector< uint_fast32_t > indices = Utilities::argsort(keys);
+  for (uint_fast8_t i = 0; i < 64; ++i) {
+    const CoordinateVector<> &cur_p = positions[indices[i]];
+    ofile << cur_p.x() << "\t" << cur_p.y() << "\t" << cur_p.z();
+    ofile << "\t" << std::hex << keys[indices[i]];
+    ofile << "\n";
+  }
+  ofile.close();
+
+  return 0;
+}

--- a/test/testTreeSelfGravity.cpp
+++ b/test/testTreeSelfGravity.cpp
@@ -51,14 +51,17 @@ int main(int argc, char **argv) {
   for (auto it = grid.begin(); it != grid.end(); ++it) {
     const double r = (it.get_cell_midpoint() - center).norm();
     if (r < 0.5) {
-      it.get_hydro_variables().set_conserved_mass(1.);
+      it.get_hydro_variables().set_conserved_mass(1. * it.get_volume());
     } else {
       it.get_hydro_variables().set_conserved_mass(0.);
     }
   }
 
-  TreeSelfGravity self_gravity(grid);
+  TreeSelfGravity self_gravity(grid, 0.25);
+
+  cmac_status("Computing accelerations...");
   self_gravity.compute_accelerations(grid);
+  cmac_status("Done.");
 
   std::ofstream ofile("test_treeselfgravity.txt");
   ofile << "# r (m)\ta (m s^-2)\tx (m)\ty (m)\tz (m)\tax (m s^-2)\tay (m "

--- a/test/testTreeSelfGravity.cpp
+++ b/test/testTreeSelfGravity.cpp
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * This file is part of CMacIonize
+ * Copyright (C) 2018 Bert Vandenbroucke (bert.vandenbroucke@gmail.com)
+ *
+ * CMacIonize is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CMacIonize is distributed in the hope that it will be useful,
+ * but WITOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with CMacIonize. If not, see <http://www.gnu.org/licenses/>.
+ ******************************************************************************/
+
+/**
+ * @file testTreeSelfGravity.cpp
+ *
+ * @brief Unit test for the TreeSelfGravity class.
+ *
+ * @author Bert Vandenbroucke (bv7@st-andrews.ac.uk)
+ */
+#include "CartesianDensityGrid.hpp"
+#include "HomogeneousDensityFunction.hpp"
+#include "TreeSelfGravity.hpp"
+#include <fstream>
+
+/**
+ * @brief Unit test for the TreeSelfGravity class.
+ *
+ * @param argc Number of command line arguments.
+ * @param argv Command line arguments.
+ * @return Exit code: 0 on success.
+ */
+int main(int argc, char **argv) {
+
+  Box<> box(CoordinateVector<>(0.), CoordinateVector<>(1.));
+  HomogeneousDensityFunction density_function(1.);
+  density_function.initialize();
+
+  CartesianDensityGrid grid(box, 32, false, true);
+  std::pair< cellsize_t, cellsize_t > block =
+      std::make_pair(0, grid.get_number_of_cells());
+  grid.initialize(block, density_function);
+
+  // initialize hydro variables
+  const CoordinateVector<> center(0.5);
+  for (auto it = grid.begin(); it != grid.end(); ++it) {
+    const double r = (it.get_cell_midpoint() - center).norm();
+    if (r < 0.5) {
+      it.get_hydro_variables().set_conserved_mass(1.);
+    } else {
+      it.get_hydro_variables().set_conserved_mass(0.);
+    }
+  }
+
+  TreeSelfGravity self_gravity(grid);
+  self_gravity.compute_accelerations(grid);
+
+  std::ofstream ofile("test_treeselfgravity.txt");
+  ofile << "# r (m)\ta (m s^-2)\tx (m)\ty (m)\tz (m)\tax (m s^-2)\tay (m "
+           "s^-2)\taz (m s^-2)\n";
+  for (auto it = grid.begin(); it != grid.end(); ++it) {
+    const CoordinateVector<> r = it.get_cell_midpoint() - center;
+    const double rnorm = r.norm();
+    const CoordinateVector<> a =
+        it.get_hydro_variables().get_gravitational_acceleration();
+    const double anorm = a.norm();
+    ofile << rnorm << "\t" << anorm << "\t" << r.x() << "\t" << r.y() << "\t"
+          << r.z() << "\t" << a.x() << "\t" << a.y() << "\t" << a.z() << "\n";
+  }
+
+  return 0;
+}


### PR DESCRIPTION
## Description of the new code

Added a tree based self-gravity module that can be used as part of an RHD simulation.

## Impact of the new code

Code consists of additional independent modules, a new unit test and an additional output field. Should not affect any of the old behaviour. Self-gravity is off by default and can be switched on by setting the relevant new RHDSimulation parameter.