### PR TITLE
Ubuntu 18.04 upgrade

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -287,8 +287,8 @@ else(MPI_CXX_FOUND)
           "MPI not found. Distributed memory parallelization will not work.")
 endif(MPI_CXX_FOUND)
 
-# Find Boost, Boost Python, Python, and NumPy
-find_package(Boost COMPONENTS "python")
+# Find Boost, Boost Python, Boost NumPy, Python, and NumPy
+find_package(Boost 1.63.0 COMPONENTS "numpy")
 if(Boost_FOUND)
   find_package(PythonLibs 2.7)
   find_package(PythonInterp 2.7)
@@ -302,7 +302,7 @@ if(Boost_FOUND)
       message(STATUS
              "Python, NumPy and Boost Python found. Will build Python modules.")
       include_directories(${Boost_INCLUDE_DIRS})
-      include_directories(${PYTHON_INCLUDE_PATH})
+      include_directories(${PYTHON_INCLUDE_DIRS})
       include_directories(${NUMPY_OUTPUT})
       set(BOOST_PYTHON_LIBRARIES ${Boost_LIBRARIES})
       add_configuration_option(HAVE_PYTHON True)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,6 +198,9 @@ add_compiler_flag("-Wall -Werror" OPTIONAL)
 #  before running the code)
 if(${CMAKE_BUILD_TYPE} STREQUAL "Debug")
   add_compiler_flag("-fsanitize=address -fno-omit-frame-pointer" OPTIONAL)
+  add_configuration_option(DEBUG_BUILD True)
+else(${CMAKE_BUILD_TYPE} STREQUAL "Debug")
+  add_configuration_option(DEBUG_BUILD False)
 endif(${CMAKE_BUILD_TYPE} STREQUAL "Debug")
 
 # Add a Profile CMAKE_BUILD_TYPE

--- a/format_script.sh
+++ b/format_script.sh
@@ -1,12 +1,12 @@
 #! /bin/bash
 
-command -v clang-format-3.8 >/dev/null 2>&1 || \
-  { echo >&2 "This script requires clang-format-3.8, but it is not installed!" \
+command -v clang-format-6.0 >/dev/null 2>&1 || \
+  { echo >&2 "This script requires clang-format-6.0, but it is not installed!" \
              "Aborting."; exit 1; }
 
 files=( src/*.cpp src/*.hpp src/*.cpp.in src/*.hpp.in test/*.cpp test/*.hpp \
         test/*.c python/*.cpp timing/*.cpp timing/*.hpp c/*.h )
 
 for f in "${files[@]}"
-do clang-format-3.8 -style=file -i $f
+do clang-format-6.0 -style=file -i $f
 done

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -41,8 +41,9 @@ set_target_properties(linecoolingdata PROPERTIES LIBRARY_OUTPUT_DIRECTORY
 set_target_properties(linecoolingdata PROPERTIES
                      COMPILE_FLAGS "-Wno-unused-function -fno-sanitize=address")
 set_target_properties(linecoolingdata PROPERTIES
-                      LINK_FLAGS "-fno-sanitize=address")
+                      LINK_FLAGS "-fno-sanitize=address -Wl,--no-undefined")
 target_link_libraries(linecoolingdata ${BOOST_PYTHON_LIBRARIES})
+target_link_libraries(linecoolingdata ${PYTHON_LIBRARIES})
 
 # DensityGridModule
 if(HAVE_HDF5)
@@ -69,8 +70,9 @@ if(HAVE_HDF5)
   set_target_properties(densitygrid PROPERTIES
                         COMPILE_FLAGS "-fno-sanitize=address")
   set_target_properties(densitygrid PROPERTIES
-                        LINK_FLAGS "-fno-sanitize=address")
+                        LINK_FLAGS "-fno-sanitize=address -Wl,--no-undefined")
   target_link_libraries(densitygrid ${BOOST_PYTHON_LIBRARIES})
+  target_link_libraries(densitygrid ${PYTHON_LIBRARIES})
   target_link_libraries(densitygrid ${HDF5_LIBRARIES})
 
 endif(HAVE_HDF5)
@@ -89,8 +91,9 @@ set_target_properties(emissivitycalculator PROPERTIES LIBRARY_OUTPUT_DIRECTORY
 set_target_properties(emissivitycalculator PROPERTIES
                       COMPILE_FLAGS "-fno-sanitize=address")
 set_target_properties(emissivitycalculator PROPERTIES
-                      LINK_FLAGS "-fno-sanitize=address")
+                      LINK_FLAGS "-fno-sanitize=address -Wl,--no-undefined")
 target_link_libraries(emissivitycalculator ${BOOST_PYTHON_LIBRARIES})
+target_link_libraries(emissivitycalculator ${PYTHON_LIBRARIES})
 
 # FLASHSnapshotDensityFunctionModule
 if(HAVE_HDF5)
@@ -111,8 +114,9 @@ if(HAVE_HDF5)
   set_target_properties(flashsnapshotdensityfunction PROPERTIES
                         COMPILE_FLAGS "-fno-sanitize=address")
   set_target_properties(flashsnapshotdensityfunction PROPERTIES
-                        LINK_FLAGS "-fno-sanitize=address")
+                        LINK_FLAGS "-fno-sanitize=address -Wl,--no-undefined")
   target_link_libraries(flashsnapshotdensityfunction ${BOOST_PYTHON_LIBRARIES})
+  target_link_libraries(flashsnapshotdensityfunction ${PYTHON_LIBRARIES})
   target_link_libraries(flashsnapshotdensityfunction ${HDF5_LIBRARIES})
 
 endif(HAVE_HDF5)

--- a/python/EmissivityCalculatorModule.cpp
+++ b/python/EmissivityCalculatorModule.cpp
@@ -23,19 +23,15 @@
  *
  * @author Bert Vandenbroucke (bv7@st-andrews.ac.uk)
  */
-#include "EmissivityCalculator.hpp"
 #include "DensityGrid.hpp"
+#include "EmissivityCalculator.hpp"
 #include "LineCoolingData.hpp"
 #include <boost/python/class.hpp>
 #include <boost/python/dict.hpp>
 #include <boost/python/extract.hpp>
 #include <boost/python/make_constructor.hpp>
 #include <boost/python/module.hpp>
-#include <boost/python/numeric.hpp>
-
-/*! @brief Tell numpy to use the non deprecated API. */
-#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
-#include <numpy/ndarrayobject.h>
+#include <boost/python/numpy.hpp>
 
 /**
  * @brief Python constructor for an EmissivityCalculator.
@@ -58,10 +54,12 @@ initEmissivityCalculator(Abundances &abundances) {
  */
 static boost::python::dict get_emissivities(EmissivityCalculator &calculator,
                                             DensityGrid &grid) {
-  npy_intp size = grid.get_number_of_cells();
-  PyObject *narr = PyArray_SimpleNew(1, &size, NPY_DOUBLE);
-  boost::python::handle<> handle(narr);
-  boost::python::numeric::array arr(handle);
+
+  boost::python::tuple shape =
+      boost::python::make_tuple(grid.get_number_of_cells(), 1);
+  boost::python::numpy::dtype dtype =
+      boost::python::numpy::dtype::get_builtin< double >();
+  boost::python::numpy::ndarray arr = boost::python::numpy::zeros(shape, dtype);
 
   boost::python::dict result;
   for (int_fast32_t line = 0; line < NUMBER_OF_EMISSIONLINES; ++line) {
@@ -152,11 +150,13 @@ static boost::python::dict make_emission_map(EmissivityCalculator &calculator,
   // make sure the grid has emissivity values
   calculator.calculate_emissivities(grid);
 
-  npy_intp size[2] = {boost::python::extract< unsigned int >(shape[0]),
-                      boost::python::extract< unsigned int >(shape[1])};
-  PyObject *narr = PyArray_SimpleNew(2, size, NPY_DOUBLE);
-  boost::python::handle<> handle(narr);
-  boost::python::numeric::array arr(handle);
+  const unsigned int size[2] = {
+      boost::python::extract< unsigned int >(shape[0]),
+      boost::python::extract< unsigned int >(shape[1])};
+
+  boost::python::numpy::dtype dtype =
+      boost::python::numpy::dtype::get_builtin< double >();
+  boost::python::numpy::ndarray arr = boost::python::numpy::zeros(shape, dtype);
 
   Box<> box = grid.get_box();
 
@@ -222,11 +222,8 @@ initAbundances(boost::python::dict abundances) {
  * @brief Python module exposure.
  */
 BOOST_PYTHON_MODULE(libemissivitycalculator) {
-  // we need to tell Boost we mean numpy.ndarray whenever we write
-  // boost::python::numeric::array
-  boost::python::numeric::array::set_module_and_type("numpy", "ndarray");
-  // we have to kindly ask numpy to initialize its array functionality
-  import_array();
+  Py_Initialize();
+  boost::python::numpy::initialize();
 
   // we tell Boost we want to expose our version of
   // LineCoolingData.get_line_strengths()

--- a/python/FLASHSnapshotDensityFunctionModule.cpp
+++ b/python/FLASHSnapshotDensityFunctionModule.cpp
@@ -23,8 +23,8 @@
  *
  * @author Bert Vandenbroucke (bv7@st-andrews.ac.uk)
  */
-#include "FLASHSnapshotDensityFunction.hpp"
 #include "DensityValues.hpp"
+#include "FLASHSnapshotDensityFunction.hpp"
 #include <boost/python/class.hpp>
 #include <boost/python/def.hpp>
 #include <boost/python/module.hpp>

--- a/src/AMRDensityGrid.hpp
+++ b/src/AMRDensityGrid.hpp
@@ -371,8 +371,8 @@ public:
       }
 
       if (_log) {
-        _log->write_status("Number of cells after reset: ",
-                           _grid.get_number_of_cells(), ".");
+        _log->write_status(
+            "Number of cells after reset: ", _grid.get_number_of_cells(), ".");
       }
 
       // reset the ngbs

--- a/src/BondiProfile.hpp
+++ b/src/BondiProfile.hpp
@@ -170,8 +170,9 @@ public:
                       const CoordinateVector<> center = CoordinateVector<>(0.),
                       const double vprof_radius = 0.,
                       const double vprof_velocity = 0.)
-      : _bondi_radius(0.5 * PhysicalConstants::get_physical_constant(
-                                PHYSICALCONSTANT_NEWTON_CONSTANT) *
+      : _bondi_radius(0.5 *
+                      PhysicalConstants::get_physical_constant(
+                          PHYSICALCONSTANT_NEWTON_CONSTANT) *
                       central_mass / (sound_speed * sound_speed)),
         _bondi_density(bondi_density), _sound_speed(sound_speed),
         _ionisation_radius(ionisation_radius),

--- a/src/CMacIonize.cpp
+++ b/src/CMacIonize.cpp
@@ -108,13 +108,15 @@ int main(int argc, char **argv) {
   parser.add_required_option< std::string >(
       "params", 'p',
       "Name of the parameter file containing the simulation parameters.");
-  parser.add_option("verbose", 'v', "Set the logging level to the lowest "
-                                    "possible value to allow more output to be "
-                                    "written to the log.",
+  parser.add_option("verbose", 'v',
+                    "Set the logging level to the lowest "
+                    "possible value to allow more output to be "
+                    "written to the log.",
                     COMMANDLINEOPTION_NOARGUMENT, "false");
-  parser.add_option("logfile", 'l', "Output program logs to a file with the "
-                                    "given name, instead of to the standard "
-                                    "output.",
+  parser.add_option("logfile", 'l',
+                    "Output program logs to a file with the "
+                    "given name, instead of to the standard "
+                    "output.",
                     COMMANDLINEOPTION_STRINGARGUMENT, "CMacIonize_run.log");
   parser.add_option("dirty", 'd',
                     "Allow running a dirty code version. This is disabled by "
@@ -146,8 +148,9 @@ int main(int argc, char **argv) {
                     "Run a dusty radiative transfer simulation instead of an "
                     "ionization simulation.",
                     COMMANDLINEOPTION_NOARGUMENT, "false");
-  parser.add_option("rhd", 0, "Run a radiation hydrodynamics simulation "
-                              "instead of an ionization simulation.",
+  parser.add_option("rhd", 0,
+                    "Run a radiation hydrodynamics simulation "
+                    "instead of an ionization simulation.",
                     COMMANDLINEOPTION_NOARGUMENT, "false");
   parser.add_option("output-statistics", 's',
                     "Output statistical information about the photons.",

--- a/src/CMacIonizeSnapshotDensityFunction.cpp
+++ b/src/CMacIonizeSnapshotDensityFunction.cpp
@@ -162,8 +162,8 @@ CMacIonizeSnapshotDensityFunction::CMacIonizeSnapshotDensityFunction(
       _cartesian_grid[ix][iy][iz].set_number_density(cell_densities[i]);
       _cartesian_grid[ix][iy][iz].set_temperature(cell_temperatures[i]);
       for (int_fast32_t ion = 0; ion < NUMBER_OF_IONNAMES; ++ion) {
-        _cartesian_grid[ix][iy]
-                       [iz].set_ionic_fraction(ion, neutral_fractions[ion][i]);
+        _cartesian_grid[ix][iy][iz].set_ionic_fraction(
+            ion, neutral_fractions[ion][i]);
       }
       if (cell_velocities.size() > 0) {
         _cartesian_grid[ix][iy][iz].set_velocity(cell_velocities[i]);

--- a/src/Configuration.hpp.in
+++ b/src/Configuration.hpp.in
@@ -75,6 +75,9 @@
  *  part of the output. */
 #cmakedefine DO_OUTPUT_PHOTOIONIZATION_RATES
 
+/*! @brief Flag telling us if this is a debug build or not. */
+#cmakedefine DEBUG_BUILD
+
 /*! @brief Maximum number of shared memory threads that can be used on this
  *  system. */
 // clang-format off

--- a/src/CoordinateVector.hpp
+++ b/src/CoordinateVector.hpp
@@ -38,11 +38,15 @@
  */
 template < typename _datatype_ = double > class CoordinateVector {
 private:
+  /*! @brief Anonymous union that makes it possible to both index the vector
+   *  elements and to refer to individual components with sensible names. */
   union {
     /*! @brief Array that is used together with the union and anonymous struct
      *  to allow indexing the components. */
     _datatype_ _c[3];
 
+    /*! @brief Anonymous struct containing the individual coordinate
+     *  components. */
     struct {
       /*! @brief x coordinate. */
       _datatype_ _x;

--- a/src/CoredDMProfileDensityFunction.hpp
+++ b/src/CoredDMProfileDensityFunction.hpp
@@ -69,8 +69,9 @@ private:
    * @return Mean particle mass, @f$\mu{}m_p@f$ (in kg).
    */
   static inline double get_mean_particle_mass(const double neutral_fraction) {
-    return 0.5 * PhysicalConstants::get_physical_constant(
-                     PHYSICALCONSTANT_PROTON_MASS) *
+    return 0.5 *
+           PhysicalConstants::get_physical_constant(
+               PHYSICALCONSTANT_PROTON_MASS) *
            (1. + neutral_fraction);
   }
 

--- a/src/DensityGrid.hpp
+++ b/src/DensityGrid.hpp
@@ -177,9 +177,10 @@ public:
    * @param hydro Hydro flag.
    * @param log Log to write log messages to.
    */
-  DensityGrid(Box<> box, CoordinateVector< bool > periodic =
-                             CoordinateVector< bool >(false),
-              bool hydro = false, Log *log = nullptr)
+  DensityGrid(
+      Box<> box,
+      CoordinateVector< bool > periodic = CoordinateVector< bool >(false),
+      bool hydro = false, Log *log = nullptr)
       : _box(box), _periodicity_flags(periodic),
         _ionization_energy_H(
             UnitConverter::to_SI< QUANTITY_FREQUENCY >(13.6, "eV")),

--- a/src/DiscPatchDensityFunction.hpp
+++ b/src/DiscPatchDensityFunction.hpp
@@ -114,8 +114,9 @@ private:
    * @return Mean particle mass, @f$\mu{}m_p@f$ (in kg).
    */
   static inline double get_mean_particle_mass(const double neutral_fraction) {
-    return 0.5 * PhysicalConstants::get_physical_constant(
-                     PHYSICALCONSTANT_PROTON_MASS) *
+    return 0.5 *
+           PhysicalConstants::get_physical_constant(
+               PHYSICALCONSTANT_PROTON_MASS) *
            (1. + neutral_fraction);
   }
 

--- a/src/DustScattering.cpp
+++ b/src/DustScattering.cpp
@@ -133,10 +133,9 @@ void DustScattering::scatter(Photon &photon,
                       one_over_one_plus_cos2_scattering_angle;
     // White (1979), equation (6)
     const double scattering_angle = std::acos(cos_scattering_angle);
-    const double cos_skewed_scattering_angle =
-        std::cos(scattering_angle +
-                 _scattering_sc * 3.13 * scattering_angle *
-                     std::exp(-7. * scattering_angle * M_1_PI));
+    const double cos_skewed_scattering_angle = std::cos(
+        scattering_angle + _scattering_sc * 3.13 * scattering_angle *
+                               std::exp(-7. * scattering_angle * M_1_PI));
     const double cos2_skewed_scattering_angle =
         cos_skewed_scattering_angle * cos_skewed_scattering_angle;
     const double P4 = -_scattering_pc * P1 *

--- a/src/EmissivityCalculator.cpp
+++ b/src/EmissivityCalculator.cpp
@@ -87,22 +87,18 @@ void EmissivityCalculator::get_balmer_jump_emission(
   i = std::max(i, int_fast32_t(0));
   i = std::min(i, int_fast32_t(6));
 
-  emission_hydrogen_high = _loghplt[i] +
-                           (logt - _logttab[i]) *
-                               (_loghplt[i + 1] - _loghplt[i]) /
-                               (_logttab[i + 1] - _logttab[i]);
-  emission_hydrogen_low = _loghmit[i] +
-                          (logt - _logttab[i]) *
-                              (_loghmit[i + 1] - _loghmit[i]) /
-                              (_logttab[i + 1] - _logttab[i]);
-  emission_helium_high = _logheplt[i] +
-                         (logt - _logttab[i]) *
-                             (_logheplt[i + 1] - _logheplt[i]) /
-                             (_logttab[i + 1] - _logttab[i]);
-  emission_helium_low = _loghemit[i] +
-                        (logt - _logttab[i]) *
-                            (_loghemit[i + 1] - _loghemit[i]) /
-                            (_logttab[i + 1] - _logttab[i]);
+  emission_hydrogen_high = _loghplt[i] + (logt - _logttab[i]) *
+                                             (_loghplt[i + 1] - _loghplt[i]) /
+                                             (_logttab[i + 1] - _logttab[i]);
+  emission_hydrogen_low = _loghmit[i] + (logt - _logttab[i]) *
+                                            (_loghmit[i + 1] - _loghmit[i]) /
+                                            (_logttab[i + 1] - _logttab[i]);
+  emission_helium_high = _logheplt[i] + (logt - _logttab[i]) *
+                                            (_logheplt[i + 1] - _logheplt[i]) /
+                                            (_logttab[i + 1] - _logttab[i]);
+  emission_helium_low = _loghemit[i] + (logt - _logttab[i]) *
+                                           (_loghemit[i + 1] - _loghemit[i]) /
+                                           (_logttab[i + 1] - _logttab[i]);
 
   emission_hydrogen_high = std::exp(emission_hydrogen_high);
   emission_hydrogen_low = std::exp(emission_hydrogen_low);
@@ -384,11 +380,11 @@ EmissivityValues EmissivityCalculator::calculate_emissivities(
     eval.set_emissivity(EMISSIONLINE_HeI_5876,
                         ne * nhep * 1.69e-38 * std::pow(T4, -1.065));
     // Verner & Ferland (1996), table 1
-    eval.set_emissivity(EMISSIONLINE_Hrec_s,
-                        ne * nhp * 7.982e-23 /
-                            (std::sqrt(T / 3.148) *
-                             std::pow(1. + std::sqrt(T / 3.148), 0.252) *
-                             std::pow(1. + std::sqrt(T / 7.036e5), 1.748)));
+    eval.set_emissivity(
+        EMISSIONLINE_Hrec_s,
+        ne * nhp * 7.982e-23 /
+            (std::sqrt(T / 3.148) * std::pow(1. + std::sqrt(T / 3.148), 0.252) *
+             std::pow(1. + std::sqrt(T / 7.036e5), 1.748)));
 
     // HST WFC2 filters
     // wavelength ranges were based on data found on

--- a/src/FaucherGiguerePhotonSourceSpectrum.cpp
+++ b/src/FaucherGiguerePhotonSourceSpectrum.cpp
@@ -55,9 +55,9 @@ FaucherGiguerePhotonSourceSpectrum::FaucherGiguerePhotonSourceSpectrum(
   const double max_frequency = 4. * min_frequency;
   for (uint_fast32_t i = 0; i < FAUCHERGIGUEREPHOTONSOURCESPECTRUM_NUMFREQ;
        ++i) {
-    _frequencies[i] = min_frequency +
-                      i * (max_frequency - min_frequency) /
-                          (FAUCHERGIGUEREPHOTONSOURCESPECTRUM_NUMFREQ - 1.);
+    _frequencies[i] =
+        min_frequency + i * (max_frequency - min_frequency) /
+                            (FAUCHERGIGUEREPHOTONSOURCESPECTRUM_NUMFREQ - 1.);
   }
 
   // find the redshift bin that contains the requested redshift (we have values

--- a/src/HDF5Tools.hpp
+++ b/src/HDF5Tools.hpp
@@ -1726,6 +1726,6 @@ inline void append_dataset(hid_t group, std::string name, hsize_t offset,
 
   delete[] data;
 }
-}
+} // namespace HDF5Tools
 
 #endif // HDF5TOOLS_HPP

--- a/src/HeliumLymanContinuumSpectrum.cpp
+++ b/src/HeliumLymanContinuumSpectrum.cpp
@@ -66,9 +66,9 @@ HeliumLymanContinuumSpectrum::HeliumLymanContinuumSpectrum(
 
   // set up the frequency bins
   for (uint_fast32_t i = 0; i < HELIUMLYMANCONTINUUMSPECTRUM_NUMFREQ; ++i) {
-    _frequency[i] = min_frequency +
-                    i * (max_frequency - min_frequency) /
-                        (HELIUMLYMANCONTINUUMSPECTRUM_NUMFREQ - 1.);
+    _frequency[i] =
+        min_frequency + i * (max_frequency - min_frequency) /
+                            (HELIUMLYMANCONTINUUMSPECTRUM_NUMFREQ - 1.);
   }
 
   // set up the temperature bins and precompute the spectrum
@@ -150,10 +150,10 @@ double HeliumLymanContinuumSpectrum::get_random_frequency(
   const uint_fast32_t inu2 =
       Utilities::locate(x, _cumulative_distribution[iT + 1].data(),
                         HELIUMLYMANCONTINUUMSPECTRUM_NUMFREQ);
-  const double frequency = _frequency[inu1] +
-                           (temperature - _temperature[iT]) *
-                               (_frequency[inu2] - _frequency[inu1]) /
-                               (_temperature[iT + 1] - _temperature[iT]);
+  const double frequency =
+      _frequency[inu1] + (temperature - _temperature[iT]) *
+                             (_frequency[inu2] - _frequency[inu1]) /
+                             (_temperature[iT + 1] - _temperature[iT]);
   return frequency;
 }
 

--- a/src/HeliumTwoPhotonContinuumSpectrum.cpp
+++ b/src/HeliumTwoPhotonContinuumSpectrum.cpp
@@ -56,9 +56,9 @@ HeliumTwoPhotonContinuumSpectrum::HeliumTwoPhotonContinuumSpectrum() {
   const double max_frequency = 1.6 * min_frequency;
   const double nu0 = 4.98e15;
   for (uint_fast32_t i = 0; i < HELIUMTWOPHOTONCONTINUUMSPECTRUM_NUMFREQ; ++i) {
-    _frequency[i] = min_frequency +
-                    i * (max_frequency - min_frequency) /
-                        (HELIUMTWOPHOTONCONTINUUMSPECTRUM_NUMFREQ - 1.);
+    _frequency[i] =
+        min_frequency + i * (max_frequency - min_frequency) /
+                            (HELIUMTWOPHOTONCONTINUUMSPECTRUM_NUMFREQ - 1.);
   }
   _cumulative_distribution[0] = 0.;
   // NOTE that we compute every y1/y2 twice (except the first and last bin edge)

--- a/src/HydroIntegrator.hpp
+++ b/src/HydroIntegrator.hpp
@@ -306,12 +306,10 @@ private:
           graduR = graduL;
           gradPR = gradPL;
           for (uint_fast8_t i = 0; i < 3; ++i) {
-            if ((normal[i] < 0. &&
-                 _hydro_integrator._boundaries[2 * i] ==
-                     HYDRO_BOUNDARY_REFLECTIVE) ||
-                (normal[i] > 0. &&
-                 _hydro_integrator._boundaries[2 * i + 1] ==
-                     HYDRO_BOUNDARY_REFLECTIVE)) {
+            if ((normal[i] < 0. && _hydro_integrator._boundaries[2 * i] ==
+                                       HYDRO_BOUNDARY_REFLECTIVE) ||
+                (normal[i] > 0. && _hydro_integrator._boundaries[2 * i + 1] ==
+                                       HYDRO_BOUNDARY_REFLECTIVE)) {
               uR[i] = -uR[i];
               gradrhoR[i] = -gradrhoR[i];
               // we only invert the gradient components not orthogonal to the
@@ -428,14 +426,15 @@ private:
             rhoL_prime, uL_prime, PL_prime, rhoR_prime, uR_prime, PR_prime,
             mflux, pflux, Eflux, normal, vframe);
 
-        cmac_assert_message(
-            mflux == mflux, "rhoL_prime: %g, uL_prime: %g %g %g, PL_prime: %g, "
+        cmac_assert_message(mflux == mflux,
+                            "rhoL_prime: %g, uL_prime: %g %g %g, PL_prime: %g, "
                             "rhoR_prime: %g, uR_prime: %g %g %g, PR_prime: %g, "
                             "normal: %g %g %g, vframe: %g %g %g",
-            rhoL_prime, uL_prime.x(), uL_prime.y(), uL_prime.z(), PL_prime,
-            rhoR_prime, uR_prime.x(), uR_prime.y(), uR_prime.z(), PR_prime,
-            normal.x(), normal.y(), normal.z(), vframe.x(), vframe.y(),
-            vframe.z());
+                            rhoL_prime, uL_prime.x(), uL_prime.y(),
+                            uL_prime.z(), PL_prime, rhoR_prime, uR_prime.x(),
+                            uR_prime.y(), uR_prime.z(), PR_prime, normal.x(),
+                            normal.y(), normal.z(), vframe.x(), vframe.y(),
+                            vframe.z());
         cmac_assert_message(pflux.x() == pflux.x(),
                             "rhoL_prime: %g, uL_prime: %g %g %g, PL_prime: %g, "
                             "rhoR_prime: %g, uR_prime: %g %g %g, PR_prime: %g, "
@@ -1066,9 +1065,9 @@ public:
             halfdt * (rho * divv + CoordinateVector<>::dot_product(u, drho));
         const CoordinateVector<> u_new =
             u - halfdt * (u * divv + rho_inv * dP - a);
-        const double P_new = P -
-                             halfdt * (_gamma * P * divv +
-                                       CoordinateVector<>::dot_product(u, dP));
+        const double P_new =
+            P - halfdt * (_gamma * P * divv +
+                          CoordinateVector<>::dot_product(u, dP));
 
         // update variables
         it.get_hydro_variables().primitives(0) = rho_new;
@@ -1257,11 +1256,10 @@ public:
         if (_gamma > 1.) {
           // E = V*(rho*u + 0.5*rho*v^2) = (V*P/(gamma-1) + 0.5*m*v^2)
           // P = (E - 0.5*m*v^2)*(gamma-1)/V
-          pressure =
-              _gm1 *
-              (total_energy -
-               0.5 * CoordinateVector<>::dot_product(velocity, momentum)) /
-              volume;
+          pressure = _gm1 *
+                     (total_energy - 0.5 * CoordinateVector<>::dot_product(
+                                               velocity, momentum)) /
+                     volume;
           temperature =
               mean_molecular_mass * _T_conversion_factor * pressure / density;
         } else {

--- a/src/HydrogenLymanContinuumSpectrum.cpp
+++ b/src/HydrogenLymanContinuumSpectrum.cpp
@@ -61,9 +61,9 @@ HydrogenLymanContinuumSpectrum::HydrogenLymanContinuumSpectrum(
 
   // set up the frequency bins
   for (uint_fast32_t i = 0; i < HYDROGENLYMANCONTINUUMSPECTRUM_NUMFREQ; ++i) {
-    _frequency[i] = min_frequency +
-                    i * (max_frequency - min_frequency) /
-                        (HYDROGENLYMANCONTINUUMSPECTRUM_NUMFREQ - 1.);
+    _frequency[i] =
+        min_frequency + i * (max_frequency - min_frequency) /
+                            (HYDROGENLYMANCONTINUUMSPECTRUM_NUMFREQ - 1.);
   }
 
   // set up the temperature bins and precompute the spectrum
@@ -145,10 +145,10 @@ double HydrogenLymanContinuumSpectrum::get_random_frequency(
   const uint_fast32_t inu2 =
       Utilities::locate(x, _cumulative_distribution[iT + 1].data(),
                         HYDROGENLYMANCONTINUUMSPECTRUM_NUMFREQ);
-  const double frequency = _frequency[inu1] +
-                           (temperature - _temperature[iT]) *
-                               (_frequency[inu2] - _frequency[inu1]) /
-                               (_temperature[iT + 1] - _temperature[iT]);
+  const double frequency =
+      _frequency[inu1] + (temperature - _temperature[iT]) *
+                             (_frequency[inu2] - _frequency[inu1]) /
+                             (_temperature[iT + 1] - _temperature[iT]);
   return frequency;
 }
 

--- a/src/IonizationSimulation.cpp
+++ b/src/IonizationSimulation.cpp
@@ -376,8 +376,9 @@ void IonizationSimulation::run(DensityGridWriter *density_grid_writer) {
         _log->write_status(
             100. * typecount[PHOTONTYPE_ABSORBED] / totweight,
             "% of photons were reemitted as non-ionizing photons.");
-        _log->write_status(100. * (typecount[PHOTONTYPE_DIFFUSE_HI] +
-                                   typecount[PHOTONTYPE_DIFFUSE_HeI]) /
+        _log->write_status(100. *
+                               (typecount[PHOTONTYPE_DIFFUSE_HI] +
+                                typecount[PHOTONTYPE_DIFFUSE_HeI]) /
                                totweight,
                            "% of photons were scattered.");
         double escape_fraction =

--- a/src/IonizationStateCalculator.cpp
+++ b/src/IonizationStateCalculator.cpp
@@ -266,12 +266,10 @@ void IonizationStateCalculator::compute_ionization_states_metals(
   const double C32 =
       jCp2 /
       (ne * alphaC[1] +
-       nh0 *
-           charge_transfer_rates.get_charge_transfer_recombination_rate_H(
-               ION_C_p2, T4) +
-       nhe0 *
-           charge_transfer_rates.get_charge_transfer_recombination_rate_He(
-               ION_C_p2, T4));
+       nh0 * charge_transfer_rates.get_charge_transfer_recombination_rate_H(
+                 ION_C_p2, T4) +
+       nhe0 * charge_transfer_rates.get_charge_transfer_recombination_rate_He(
+                  ION_C_p2, T4));
   const double C31 = C32 * C21;
   const double sumC_inv = 1. / (1. + C21 + C31);
   ionization_variables.set_ionic_fraction(ION_C_p1, C21 * sumC_inv);
@@ -279,32 +277,25 @@ void IonizationStateCalculator::compute_ionization_states_metals(
 
   // nitrogen
   const double N21 =
-      (jNn +
-       nhp *
-           charge_transfer_rates.get_charge_transfer_ionization_rate_H(ION_N_n,
-                                                                       T4)) /
+      (jNn + nhp * charge_transfer_rates.get_charge_transfer_ionization_rate_H(
+                       ION_N_n, T4)) /
       (ne * alphaN[0] +
-       nh0 *
-           charge_transfer_rates.get_charge_transfer_recombination_rate_H(
-               ION_N_n, T4));
+       nh0 * charge_transfer_rates.get_charge_transfer_recombination_rate_H(
+                 ION_N_n, T4));
   const double N32 =
       jNp1 /
       (ne * alphaN[1] +
-       nh0 *
-           charge_transfer_rates.get_charge_transfer_recombination_rate_H(
-               ION_N_p1, T4) +
-       nhe0 *
-           charge_transfer_rates.get_charge_transfer_recombination_rate_He(
-               ION_N_p1, T4));
+       nh0 * charge_transfer_rates.get_charge_transfer_recombination_rate_H(
+                 ION_N_p1, T4) +
+       nhe0 * charge_transfer_rates.get_charge_transfer_recombination_rate_He(
+                  ION_N_p1, T4));
   const double N43 =
       jNp2 /
       (ne * alphaN[2] +
-       nh0 *
-           charge_transfer_rates.get_charge_transfer_recombination_rate_H(
-               ION_N_p2, T4) +
-       nhe0 *
-           charge_transfer_rates.get_charge_transfer_recombination_rate_He(
-               ION_N_p2, T4));
+       nh0 * charge_transfer_rates.get_charge_transfer_recombination_rate_H(
+                 ION_N_p2, T4) +
+       nhe0 * charge_transfer_rates.get_charge_transfer_recombination_rate_He(
+                  ION_N_p2, T4));
   const double N31 = N32 * N21;
   const double N41 = N43 * N31;
   const double sumN_inv = 1. / (1. + N21 + N31 + N41);
@@ -314,23 +305,18 @@ void IonizationStateCalculator::compute_ionization_states_metals(
 
   // Oxygen
   const double O21 =
-      (jOn +
-       nhp *
-           charge_transfer_rates.get_charge_transfer_ionization_rate_H(ION_O_n,
-                                                                       T4)) /
+      (jOn + nhp * charge_transfer_rates.get_charge_transfer_ionization_rate_H(
+                       ION_O_n, T4)) /
       (ne * alphaO[0] +
-       nh0 *
-           charge_transfer_rates.get_charge_transfer_recombination_rate_H(
-               ION_O_n, T4));
+       nh0 * charge_transfer_rates.get_charge_transfer_recombination_rate_H(
+                 ION_O_n, T4));
   const double O32 =
       jOp1 /
       (ne * alphaO[1] +
-       nh0 *
-           charge_transfer_rates.get_charge_transfer_recombination_rate_H(
-               ION_O_p1, T4) +
-       nhe0 *
-           charge_transfer_rates.get_charge_transfer_recombination_rate_He(
-               ION_O_p1, T4));
+       nh0 * charge_transfer_rates.get_charge_transfer_recombination_rate_H(
+                 ION_O_p1, T4) +
+       nhe0 * charge_transfer_rates.get_charge_transfer_recombination_rate_He(
+                  ION_O_p1, T4));
   const double O31 = O32 * O21;
   const double sumO_inv = 1. / (1. + O21 + O31);
   ionization_variables.set_ionic_fraction(ION_O_n, O21 * sumO_inv);
@@ -341,12 +327,10 @@ void IonizationStateCalculator::compute_ionization_states_metals(
   const double Ne32 =
       jNep1 /
       (ne * alphaNe[1] +
-       nh0 *
-           charge_transfer_rates.get_charge_transfer_recombination_rate_H(
-               ION_Ne_p1, T4) +
-       nhe0 *
-           charge_transfer_rates.get_charge_transfer_recombination_rate_He(
-               ION_Ne_p1, T4));
+       nh0 * charge_transfer_rates.get_charge_transfer_recombination_rate_H(
+                 ION_Ne_p1, T4) +
+       nhe0 * charge_transfer_rates.get_charge_transfer_recombination_rate_He(
+                  ION_Ne_p1, T4));
   const double Ne31 = Ne32 * Ne21;
   const double sumNe_inv = 1. / (1. + Ne21 + Ne31);
   ionization_variables.set_ionic_fraction(ION_Ne_n, Ne21 * sumNe_inv);
@@ -356,27 +340,22 @@ void IonizationStateCalculator::compute_ionization_states_metals(
   const double S21 =
       jSp1 /
       (ne * alphaS[0] +
-       nh0 *
-           charge_transfer_rates.get_charge_transfer_recombination_rate_H(
-               ION_S_p1, T4));
+       nh0 * charge_transfer_rates.get_charge_transfer_recombination_rate_H(
+                 ION_S_p1, T4));
   const double S32 =
       jSp2 /
       (ne * alphaS[1] +
-       nh0 *
-           charge_transfer_rates.get_charge_transfer_recombination_rate_H(
-               ION_S_p2, T4) +
-       nhe0 *
-           charge_transfer_rates.get_charge_transfer_recombination_rate_He(
-               ION_S_p2, T4));
+       nh0 * charge_transfer_rates.get_charge_transfer_recombination_rate_H(
+                 ION_S_p2, T4) +
+       nhe0 * charge_transfer_rates.get_charge_transfer_recombination_rate_He(
+                  ION_S_p2, T4));
   const double S43 =
       jSp3 /
       (ne * alphaS[2] +
-       nh0 *
-           charge_transfer_rates.get_charge_transfer_recombination_rate_H(
-               ION_S_p3, T4) +
-       nhe0 *
-           charge_transfer_rates.get_charge_transfer_recombination_rate_He(
-               ION_S_p3, T4));
+       nh0 * charge_transfer_rates.get_charge_transfer_recombination_rate_H(
+                 ION_S_p3, T4) +
+       nhe0 * charge_transfer_rates.get_charge_transfer_recombination_rate_He(
+                  ION_S_p3, T4));
   const double S31 = S32 * S21;
   const double S41 = S43 * S31;
   const double sumS_inv = 1. / (1. + S21 + S31 + S41);

--- a/src/IsotropicContinuousPhotonSource.hpp
+++ b/src/IsotropicContinuousPhotonSource.hpp
@@ -169,9 +169,9 @@ public:
       // epsilon is the difference between 1.0 and the next floating point value
       // larger than 1.0 that can be represented as a 64-bit floating point.
       position[i] =
-          std::min(position[i], anchor_top[i] -
-                                    std::numeric_limits< double >::epsilon() *
-                                        _box.get_sides()[i]);
+          std::min(position[i],
+                   anchor_top[i] - std::numeric_limits< double >::epsilon() *
+                                       _box.get_sides()[i]);
       position[i] = std::max(position[i], anchor_bottom[i]);
     }
 

--- a/src/LineCoolingData.cpp
+++ b/src/LineCoolingData.cpp
@@ -1725,9 +1725,8 @@ double LineCoolingData::compute_level_population(
        _two_level_collision_strength[i][2] * Tinv +
        _two_level_collision_strength[i][3] * logT +
        _two_level_collision_strength[i][4] * T *
-           (1. +
-            (_two_level_collision_strength[i][5] - 1.) *
-                std::pow(T, _two_level_collision_strength[i][6])));
+           (1. + (_two_level_collision_strength[i][5] - 1.) *
+                     std::pow(T, _two_level_collision_strength[i][6])));
   const double inv_omega_1 = _two_level_inverse_statistical_weight[i][0];
   const double inv_omega_2 = _two_level_inverse_statistical_weight[i][1];
   const double Texp = std::exp(-ksi * Tinv);

--- a/src/MD5Sum.hpp
+++ b/src/MD5Sum.hpp
@@ -293,6 +293,6 @@ inline std::string get_file_checksum(std::string filename) {
   }
   return get_checksum(filestream);
 }
-}
+} // namespace MD5Sum
 
 #endif // MD5SUM_HPP

--- a/src/MPICommunicator.hpp
+++ b/src/MPICommunicator.hpp
@@ -46,14 +46,14 @@
 #include <unistd.h>
 #endif
 
-#if defined(__clang__)
+#if defined(__clang__) && defined(DEBUG_BUILD)
 // header containing functions to temporarily disable the address sanitizer
 #include <sanitizer/lsan_interface.h>
 #endif
 
 /*! @brief Temporarily disable instrumentation for memory allocations done
  *  between the call to this macro, and the call to NO_LEAK_CHECK_END. */
-#if defined(__clang__)
+#if defined(__clang__) && defined(DEBUG_BUILD)
 #define NO_LEAK_CHECK_BEGIN __lsan_disable();
 #else
 #define NO_LEAK_CHECK_BEGIN
@@ -61,7 +61,7 @@
 
 /*! @brief Re-enable instrumentation after it was disabled by
  *  NO_LEAK_CHECK_BEGIN. */
-#if defined(__clang__)
+#if defined(__clang__) && defined(DEBUG_BUILD)
 #define NO_LEAK_CHECK_END __lsan_enable();
 #else
 #define NO_LEAK_CHECK_END

--- a/src/MPIMessage.hpp
+++ b/src/MPIMessage.hpp
@@ -59,12 +59,15 @@
  */
 class MPITagSizeMessage {
 private:
+  /*! @brief Anonymous union that makes it possible to both index the message
+   *  properties and access them individually using sensible names. */
   union {
     /*! @brief Array containing the actual data of the message. We use this
      *  in an anonymous union with an anonymous struct to be able to assign
      *  meaningful names to the array elements. */
     int _array[3];
 
+    /*! @brief Anonymous struct grouping the individual message properties. */
     struct {
       /*! @brief Type of the message announced by this message. */
       int _type;

--- a/src/MPIUtilities.hpp
+++ b/src/MPIUtilities.hpp
@@ -88,7 +88,7 @@ template <> inline MPI_Datatype get_datatype< unsigned long >() {
  * @return MPI_INT.
  */
 template <> inline MPI_Datatype get_datatype< int >() { return MPI_INT; }
-}
+} // namespace MPIUtilities
 
 #endif // HAVE_MPI
 

--- a/src/NewVoronoiCellConstructor.cpp
+++ b/src/NewVoronoiCellConstructor.cpp
@@ -744,9 +744,8 @@ void NewVoronoiCellConstructor::two_to_six_flip(uint_fast32_t new_vertex,
   for (uint_fast8_t i = 0; i < 4; ++i) {
     uint_fast8_t t0 = i;
     uint_fast8_t t1 = 0;
-    while (t1 < 4 &&
-           _tetrahedra[tetrahedra[0]].get_vertex(t0) !=
-               _tetrahedra[tetrahedra[1]].get_vertex(t1)) {
+    while (t1 < 4 && _tetrahedra[tetrahedra[0]].get_vertex(t0) !=
+                         _tetrahedra[tetrahedra[1]].get_vertex(t1)) {
       ++t1;
     }
     if (t1 < 4) {
@@ -910,9 +909,8 @@ void NewVoronoiCellConstructor::n_to_2n_flip(uint_fast32_t new_vertex,
     bool is_axis = true;
     for (uint_fast8_t j = 1; j < n; ++j) {
       tj[j] = 0;
-      while (tj[j] < 4 &&
-             _tetrahedra[tetrahedra[0]].get_vertex(tj[0]) !=
-                 _tetrahedra[tetrahedra[j]].get_vertex(tj[j])) {
+      while (tj[j] < 4 && _tetrahedra[tetrahedra[0]].get_vertex(tj[0]) !=
+                              _tetrahedra[tetrahedra[j]].get_vertex(tj[j])) {
         ++tj[j];
       }
       is_axis &= (tj[j] < 4);
@@ -1194,21 +1192,18 @@ void NewVoronoiCellConstructor::four_to_four_flip(uint_fast32_t tetrahedron0,
     uint_fast8_t t0, t1, t2, t3;
     t0 = i;
     t1 = 0;
-    while (t1 < 4 &&
-           _tetrahedra[tetrahedron0].get_vertex(t0) !=
-               _tetrahedra[tetrahedron1].get_vertex(t1)) {
+    while (t1 < 4 && _tetrahedra[tetrahedron0].get_vertex(t0) !=
+                         _tetrahedra[tetrahedron1].get_vertex(t1)) {
       ++t1;
     }
     t2 = 0;
-    while (t2 < 4 &&
-           _tetrahedra[tetrahedron0].get_vertex(t0) !=
-               _tetrahedra[tetrahedron2].get_vertex(t2)) {
+    while (t2 < 4 && _tetrahedra[tetrahedron0].get_vertex(t0) !=
+                         _tetrahedra[tetrahedron2].get_vertex(t2)) {
       ++t2;
     }
     t3 = 0;
-    while (t3 < 4 &&
-           _tetrahedra[tetrahedron0].get_vertex(t0) !=
-               _tetrahedra[tetrahedron3].get_vertex(t3)) {
+    while (t3 < 4 && _tetrahedra[tetrahedron0].get_vertex(t0) !=
+                         _tetrahedra[tetrahedron3].get_vertex(t3)) {
       ++t3;
     }
     if (t1 < 4 && t2 < 4 && t3 < 4) {
@@ -1406,15 +1401,13 @@ void NewVoronoiCellConstructor::three_to_two_flip(uint_fast32_t tetrahedron0,
   for (uint_fast8_t i = 0; i < 4; ++i) {
     uint_fast8_t t0 = i;
     uint_fast8_t t1 = 0;
-    while (t1 < 4 &&
-           _tetrahedra[tetrahedron0].get_vertex(t0) !=
-               _tetrahedra[tetrahedron1].get_vertex(t1)) {
+    while (t1 < 4 && _tetrahedra[tetrahedron0].get_vertex(t0) !=
+                         _tetrahedra[tetrahedron1].get_vertex(t1)) {
       ++t1;
     }
     uint_fast8_t t2 = 0;
-    while (t2 < 4 &&
-           _tetrahedra[tetrahedron0].get_vertex(t0) !=
-               _tetrahedra[tetrahedron2].get_vertex(t2)) {
+    while (t2 < 4 && _tetrahedra[tetrahedron0].get_vertex(t0) !=
+                         _tetrahedra[tetrahedron2].get_vertex(t2)) {
       ++t2;
     }
     if (t1 < 4 && t2 < 4) {

--- a/src/NewVoronoiGrid.cpp
+++ b/src/NewVoronoiGrid.cpp
@@ -160,17 +160,14 @@ NewVoronoiGrid::NewVoronoiGrid(
   const double box_bottom_anchor_z =
       1. + (box.get_anchor().z() - min_anchor.z()) / max_anchor.z();
   const double box_top_anchor_x =
-      1. +
-      (box.get_anchor().x() + box.get_sides().x() - min_anchor.x()) /
-          max_anchor.x();
+      1. + (box.get_anchor().x() + box.get_sides().x() - min_anchor.x()) /
+               max_anchor.x();
   const double box_top_anchor_y =
-      1. +
-      (box.get_anchor().y() + box.get_sides().y() - min_anchor.y()) /
-          max_anchor.y();
+      1. + (box.get_anchor().y() + box.get_sides().y() - min_anchor.y()) /
+               max_anchor.y();
   const double box_top_anchor_z =
-      1. +
-      (box.get_anchor().z() + box.get_sides().z() - min_anchor.z()) /
-          max_anchor.z();
+      1. + (box.get_anchor().z() + box.get_sides().z() - min_anchor.z()) /
+               max_anchor.z();
 
   _real_rescaled_box = NewVoronoiBox(
       Box<>(CoordinateVector<>(box_bottom_anchor_x, box_bottom_anchor_y,

--- a/src/NewVoronoiGrid.hpp
+++ b/src/NewVoronoiGrid.hpp
@@ -228,8 +228,9 @@ public:
   /// constructor and destructor
 
   NewVoronoiGrid(const std::vector< CoordinateVector<> > &positions,
-                 const Box<> box, const CoordinateVector< bool > periodic =
-                                      CoordinateVector< bool >(false));
+                 const Box<> box,
+                 const CoordinateVector< bool > periodic =
+                     CoordinateVector< bool >(false));
   virtual ~NewVoronoiGrid();
 
   /// grid computation methods

--- a/src/OldVoronoiGrid.cpp
+++ b/src/OldVoronoiGrid.cpp
@@ -361,9 +361,9 @@ OldVoronoiGrid::get_index(const CoordinateVector<> &position) const {
   CoordinateVector<> pos(position);
   // unit conversion
   for (uint_fast8_t i = 0; i < 3; ++i) {
-    pos[i] = _internal_box.get_anchor()[i] +
-             (pos[i] - _box.get_anchor()[i]) * _internal_box.get_sides()[i] /
-                 _box.get_sides()[i];
+    pos[i] = _internal_box.get_anchor()[i] + (pos[i] - _box.get_anchor()[i]) *
+                                                 _internal_box.get_sides()[i] /
+                                                 _box.get_sides()[i];
   }
   return _pointlocations->get_closest_neighbour(pos);
 }

--- a/src/OldVoronoiGrid.hpp
+++ b/src/OldVoronoiGrid.hpp
@@ -197,8 +197,9 @@ public:
   /// constructor and destructor
 
   OldVoronoiGrid(const std::vector< CoordinateVector<> > &positions,
-                 const Box<> box, const CoordinateVector< bool > periodic =
-                                      CoordinateVector< bool >(false));
+                 const Box<> box,
+                 const CoordinateVector< bool > periodic =
+                     CoordinateVector< bool >(false));
 
   virtual ~OldVoronoiGrid();
 

--- a/src/OperatingSystem.hpp
+++ b/src/OperatingSystem.hpp
@@ -111,7 +111,7 @@ static size_t get_peak_memory_usage();
  * interrupts are sent by the operating system (e.g. CTRL+C from the terminal).
  */
 static void install_signal_handlers();
-}
+} // namespace OperatingSystem
 
 // ...then include the correct implementation
 #ifdef HAVE_WINDOWS

--- a/src/ParallelCartesianDensitySubGrid.hpp
+++ b/src/ParallelCartesianDensitySubGrid.hpp
@@ -396,8 +396,8 @@ public:
                                   CoordinateVector< int_fast32_t > numcell)
       : DensitySubGrid(numcell.x() * numcell.y() * numcell.z()),
         DensitySubGridVariables(numcell.x() * numcell.y() * numcell.z()),
-        _box(box), _numcell(numcell.x(), numcell.y(), numcell.z()), _index(-1),
-        _neighbours{-1, -1, -1, -1, -1, -1} {
+        _box(box), _numcell(numcell.x(), numcell.y(), numcell.z()),
+        _index(-1), _neighbours{-1, -1, -1, -1, -1, -1} {
     _cellsides[0] = box.get_sides().x() / numcell.x();
     _cellsides[1] = box.get_sides().y() / numcell.y();
     _cellsides[2] = box.get_sides().z() / numcell.z();

--- a/src/PhotonSourceDistribution.hpp
+++ b/src/PhotonSourceDistribution.hpp
@@ -87,13 +87,13 @@ public:
   virtual bool update(const double simulation_time) { return false; }
 
   /**
-  * @brief Add stellar feedback to the given grid at the given time.
-  *
-  * Not all source distributions support stellar feedback.
-  *
-  * @param grid DensityGrid to operate on.
-  * @param current_time Current simulation time (in s).
-  */
+   * @brief Add stellar feedback to the given grid at the given time.
+   *
+   * Not all source distributions support stellar feedback.
+   *
+   * @param grid DensityGrid to operate on.
+   * @param current_time Current simulation time (in s).
+   */
   virtual void add_stellar_feedback(DensityGrid &grid,
                                     const double current_time) {}
 

--- a/src/PlanckPhotonSourceSpectrum.cpp
+++ b/src/PlanckPhotonSourceSpectrum.cpp
@@ -74,9 +74,8 @@ PlanckPhotonSourceSpectrum::PlanckPhotonSourceSpectrum(double temperature,
   std::vector< double > frequency(PLANCKPHOTONSOURCESPECTRUM_NUMFREQ, 0.);
   std::vector< double > luminosity(PLANCKPHOTONSOURCESPECTRUM_NUMFREQ, 0.);
   for (uint_fast32_t i = 0; i < PLANCKPHOTONSOURCESPECTRUM_NUMFREQ; ++i) {
-    frequency[i] =
-        1. +
-        i * (max_frequency - 1.) / (PLANCKPHOTONSOURCESPECTRUM_NUMFREQ - 1.);
+    frequency[i] = 1. + i * (max_frequency - 1.) /
+                            (PLANCKPHOTONSOURCESPECTRUM_NUMFREQ - 1.);
     luminosity[i] = frequency[i] * frequency[i] * frequency[i] /
                     (std::exp(planck_constant * frequency[i] * min_frequency /
                               (boltzmann_constant * temperature)) -
@@ -87,8 +86,9 @@ PlanckPhotonSourceSpectrum::PlanckPhotonSourceSpectrum(double temperature,
   _cumulative_distribution[0] = 0.;
   for (uint_fast32_t i = 1; i < PLANCKPHOTONSOURCESPECTRUM_NUMFREQ; ++i) {
     _cumulative_distribution[i] = _cumulative_distribution[i - 1] +
-                                  0.5 * (luminosity[i] / frequency[i] +
-                                         luminosity[i - 1] / frequency[i - 1]) *
+                                  0.5 *
+                                      (luminosity[i] / frequency[i] +
+                                       luminosity[i - 1] / frequency[i - 1]) *
                                       (frequency[i] - frequency[i - 1]);
   }
 

--- a/src/RescaledICHydroMask.hpp
+++ b/src/RescaledICHydroMask.hpp
@@ -90,9 +90,10 @@ public:
                              const double scale_factor_velocity,
                              const double scale_factor_pressure,
                              const double delta_t = 0.)
-      : _center(center), _radius2(radius * radius),
-        _scale_factors{scale_factor_density, scale_factor_velocity,
-                       scale_factor_pressure},
+      : _center(center),
+        _radius2(radius * radius), _scale_factors{scale_factor_density,
+                                                  scale_factor_velocity,
+                                                  scale_factor_pressure},
         _delta_t(delta_t), _snap_n(0) {}
 
   /**

--- a/src/SPHNGSnapshotDensityFunction.cpp
+++ b/src/SPHNGSnapshotDensityFunction.cpp
@@ -573,10 +573,12 @@ double SPHNGSnapshotDensityFunction::full_integral(double phi, double r0,
   if (r0 >= 2.0 * h) {
     B3 = h2 * h / 4.;
   } else if (r0 > h) {
-    B3 = r03 / 4. * (-4. / 3. + (r0 / h) - 0.3 * r0h2 + 1. / 30. * r0h3 -
-                     1. / 15. * r0h_3 + 8. / 5. * r0h_2);
-    B2 = r03 / 4. * (-4. / 3. + (r0 / h) - 0.3 * r0h2 + 1. / 30. * r0h3 -
-                     1. / 15. * r0h_3);
+    B3 = r03 / 4. *
+         (-4. / 3. + (r0 / h) - 0.3 * r0h2 + 1. / 30. * r0h3 -
+          1. / 15. * r0h_3 + 8. / 5. * r0h_2);
+    B2 =
+        r03 / 4. *
+        (-4. / 3. + (r0 / h) - 0.3 * r0h2 + 1. / 30. * r0h3 - 1. / 15. * r0h_3);
   } else {
     B3 = r03 / 4. * (-2. / 3. + 0.3 * r0h2 - 0.1 * r0h3 + 7. / 5. * r0h_2);
     B2 = r03 / 4. * (-2. / 3. + 0.3 * r0h2 - 0.1 * r0h3 - 1. / 5. * r0h_2);
@@ -614,10 +616,9 @@ double SPHNGSnapshotDensityFunction::full_integral(double phi, double r0,
 
     I_1 = a / 2. * logs + I1;
     I_3 = I_1 + a * (1. + a2) / 4. * (2 * u / (1 - u * u) + logs);
-    I_5 =
-        I_3 +
-        a * (1. + a2) * (1. + a2) / 16. *
-            ((10 * u - 6 * u * u * u) / (1 - u * u) / (1 - u * u) + 3. * logs);
+    I_5 = I_3 + a * (1. + a2) * (1. + a2) / 16. *
+                    ((10 * u - 6 * u * u * u) / (1 - u * u) / (1 - u * u) +
+                     3. * logs);
 
     D2 = -1. / 6. * I_2 + 0.25 * (r0 / h) * I_3 - 0.15 * r0h2 * I_4 +
          1. / 30. * r0h3 * I_5 - 1. / 60. * r0h_3 * I1 + (B1 - B2) / r03 * I0;
@@ -641,10 +642,9 @@ double SPHNGSnapshotDensityFunction::full_integral(double phi, double r0,
 
     I_1 = a / 2. * logs + I1;
     I_3 = I_1 + a * (1. + a2) / 4. * (2 * u / (1 - u * u) + logs);
-    I_5 =
-        I_3 +
-        a * (1. + a2) * (1. + a2) / 16. *
-            ((10 * u - 6 * u * u * u) / (1 - u * u) / (1 - u * u) + 3. * logs);
+    I_5 = I_3 + a * (1. + a2) * (1. + a2) / 16. *
+                    ((10 * u - 6 * u * u * u) / (1 - u * u) / (1 - u * u) +
+                     3. * logs);
 
     D3 = 1. / 3. * I_2 - 0.25 * (r0 / h) * I_3 + 3. / 40. * r0h2 * I_4 -
          1. / 120. * r0h3 * I_5 + 4. / 15. * r0h_3 * I1 + (B2 - B3) / r03 * I0 +
@@ -669,10 +669,9 @@ double SPHNGSnapshotDensityFunction::full_integral(double phi, double r0,
 
     I_1 = a / 2. * logs + I1;
     I_3 = I_1 + a * (1. + a2) / 4. * (2 * u / (1 - u * u) + logs);
-    I_5 =
-        I_3 +
-        a * (1. + a2) * (1. + a2) / 16. *
-            ((10 * u - 6 * u * u * u) / (1 - u * u) / (1 - u * u) + 3. * logs);
+    I_5 = I_3 + a * (1. + a2) * (1. + a2) / 16. *
+                    ((10 * u - 6 * u * u * u) / (1 - u * u) / (1 - u * u) +
+                     3. * logs);
 
     D3 = 1. / 3. * I_2 - 0.25 * (r0 / h) * I_3 + 3. / 40. * r0h2 * I_4 -
          1. / 120. * r0h3 * I_5 + 4. / 15. * r0h_3 * I1 + (B2 - B3) / r03 * I0 +
@@ -706,8 +705,9 @@ double SPHNGSnapshotDensityFunction::full_integral(double phi, double r0,
   // Calculating the integral expression.
 
   if (r2 < h2) {
-    full_int = r0h3 / M_PI * (1. / 6. * I_2 - 3. / 40. * r0h2 * I_4 +
-                              1. / 40. * r0h3 * I_5 + B1 / r03 * I0);
+    full_int = r0h3 / M_PI *
+               (1. / 6. * I_2 - 3. / 40. * r0h2 * I_4 + 1. / 40. * r0h3 * I_5 +
+                B1 / r03 * I0);
   } else if (r2 < 4.0 * h2) {
     full_int = r0h3 / M_PI *
                (0.25 * (4. / 3. * I_2 - (r0 / h) * I_3 + 0.3 * r0h2 * I_4 -

--- a/src/Signals.hpp
+++ b/src/Signals.hpp
@@ -39,6 +39,6 @@ namespace Signals {
 inline void signal_interrupt_handler() {
   cmac_error("\nCTRL+C interrupt detected!");
 }
-}
+} // namespace Signals
 
 #endif // SIGNALS_HPP

--- a/src/Timer.hpp
+++ b/src/Timer.hpp
@@ -35,16 +35,16 @@
 #include "RestartWriter.hpp"
 
 /**
-  * @brief A simplified interface to the Unix system timer.
-  *
-  * The Timer automatically registers the current system time when constructed
-  * and returns the elapsed time in seconds when it is stopped.
-  *
-  * The Timer can also be used to time multiple intervals, by using the
-  * functions Timer::start and Timer::stop. The function Timer::stop always
-  * returns the total registered time, which is the sum of all individual
-  * intervals measured.
-  */
+ * @brief A simplified interface to the Unix system timer.
+ *
+ * The Timer automatically registers the current system time when constructed
+ * and returns the elapsed time in seconds when it is stopped.
+ *
+ * The Timer can also be used to time multiple intervals, by using the
+ * functions Timer::start and Timer::stop. The function Timer::stop always
+ * returns the total registered time, which is the sum of all individual
+ * intervals measured.
+ */
 class Timer {
 private:
   /*! @brief Starting time of the timer */

--- a/src/Utilities.hpp
+++ b/src/Utilities.hpp
@@ -1052,6 +1052,6 @@ std::vector< uint_fast32_t > argsort(const std::vector< _datatype_ > &values) {
   });
   return idx;
 }
-}
+} // namespace Utilities
 
 #endif // UTILITIES_HPP

--- a/src/VernerRecombinationRates.hpp
+++ b/src/VernerRecombinationRates.hpp
@@ -1,20 +1,20 @@
 /*******************************************************************************
-* This file is part of CMacIonize
-* Copyright (C) 2016 Bert Vandenbroucke (bert.vandenbroucke@gmail.com)
-*
-* CMacIonize is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as published by
-* the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-*
-* CMacIonize is distributed in the hope that it will be useful,
-* but WITOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-* GNU Affero General Public License for more details.
-*
-* You should have received a copy of the GNU Affero General Public License
-* along with CMacIonize. If not, see <http://www.gnu.org/licenses/>.
-******************************************************************************/
+ * This file is part of CMacIonize
+ * Copyright (C) 2016 Bert Vandenbroucke (bert.vandenbroucke@gmail.com)
+ *
+ * CMacIonize is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CMacIonize is distributed in the hope that it will be useful,
+ * but WITOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with CMacIonize. If not, see <http://www.gnu.org/licenses/>.
+ ******************************************************************************/
 
 /**
  * @file VernerRecombinationRates.hpp

--- a/src/VoronoiGridFactory.hpp
+++ b/src/VoronoiGridFactory.hpp
@@ -56,8 +56,9 @@ public:
    */
   inline static VoronoiGrid *
   generate(std::string type, const std::vector< CoordinateVector<> > &positions,
-           const Box<> box, const CoordinateVector< bool > periodic =
-                                CoordinateVector< bool >(false)) {
+           const Box<> box,
+           const CoordinateVector< bool > periodic =
+               CoordinateVector< bool >(false)) {
 
     if (type == "New") {
       return new NewVoronoiGrid(positions, box, periodic);

--- a/src/WMBasicPhotonSourceSpectrum.cpp
+++ b/src/WMBasicPhotonSourceSpectrum.cpp
@@ -105,9 +105,9 @@ WMBasicPhotonSourceSpectrum::WMBasicPhotonSourceSpectrum(double temperature,
   const double min_frequency = 3.289e15;
   const double max_frequency = 4. * min_frequency;
   for (uint_fast32_t i = 0; i < WMBASICPHOTONSOURCESPECTRUM_NUMFREQ; ++i) {
-    _frequencies[i] = min_frequency +
-                      i * (max_frequency - min_frequency) /
-                          (WMBASICPHOTONSOURCESPECTRUM_NUMFREQ - 1.);
+    _frequencies[i] =
+        min_frequency + i * (max_frequency - min_frequency) /
+                            (WMBASICPHOTONSOURCESPECTRUM_NUMFREQ - 1.);
   }
 
   // create the spectrum in the bin range of interest

--- a/test/testChargeTransferRates.cpp
+++ b/test/testChargeTransferRates.cpp
@@ -90,10 +90,11 @@ int main(int argc, char **argv) {
       if ((atom == 7 && stage == 1) || (atom == 8 && stage == 1)) {
 
         assert_values_equal_rel(
-            ionization_rate, UnitConverter::to_unit< QUANTITY_REACTION_RATE >(
-                                 rates.get_charge_transfer_ionization_rate_H(
-                                     ion[atom][stage], temperature * 1.e-4),
-                                 "cm^3s^-1"),
+            ionization_rate,
+            UnitConverter::to_unit< QUANTITY_REACTION_RATE >(
+                rates.get_charge_transfer_ionization_rate_H(
+                    ion[atom][stage], temperature * 1.e-4),
+                "cm^3s^-1"),
             1.e-6);
       }
     }

--- a/test/testNewVoronoiGrid.cpp
+++ b/test/testNewVoronoiGrid.cpp
@@ -575,41 +575,37 @@ int main(int argc, char **argv) {
     const CoordinateVector<> full_centroid =
         full_volume_tetrahedron.get_centroid(full_volume_positions);
     const double full_area_023 =
-        0.5 *
-        CoordinateVector<>::cross_product(
-            full_volume_positions[2] - full_volume_positions[0],
-            full_volume_positions[3] - full_volume_positions[0])
-            .norm();
+        0.5 * CoordinateVector<>::cross_product(
+                  full_volume_positions[2] - full_volume_positions[0],
+                  full_volume_positions[3] - full_volume_positions[0])
+                  .norm();
     const CoordinateVector<> full_midpoint_023 =
         (full_volume_positions[0] + full_volume_positions[2] +
          full_volume_positions[3]) /
         3.;
     const double full_area_123 =
-        0.5 *
-        CoordinateVector<>::cross_product(
-            full_volume_positions[2] - full_volume_positions[1],
-            full_volume_positions[3] - full_volume_positions[1])
-            .norm();
+        0.5 * CoordinateVector<>::cross_product(
+                  full_volume_positions[2] - full_volume_positions[1],
+                  full_volume_positions[3] - full_volume_positions[1])
+                  .norm();
     const CoordinateVector<> full_midpoint_123 =
         (full_volume_positions[1] + full_volume_positions[2] +
          full_volume_positions[3]) /
         3.;
     const double full_area_013 =
-        0.5 *
-        CoordinateVector<>::cross_product(
-            full_volume_positions[1] - full_volume_positions[0],
-            full_volume_positions[3] - full_volume_positions[0])
-            .norm();
+        0.5 * CoordinateVector<>::cross_product(
+                  full_volume_positions[1] - full_volume_positions[0],
+                  full_volume_positions[3] - full_volume_positions[0])
+                  .norm();
     const CoordinateVector<> full_midpoint_013 =
         (full_volume_positions[0] + full_volume_positions[1] +
          full_volume_positions[3]) /
         3.;
     const double full_area_012 =
-        0.5 *
-        CoordinateVector<>::cross_product(
-            full_volume_positions[1] - full_volume_positions[0],
-            full_volume_positions[2] - full_volume_positions[0])
-            .norm();
+        0.5 * CoordinateVector<>::cross_product(
+                  full_volume_positions[1] - full_volume_positions[0],
+                  full_volume_positions[2] - full_volume_positions[0])
+                  .norm();
     const CoordinateVector<> full_midpoint_012 =
         (full_volume_positions[0] + full_volume_positions[1] +
          full_volume_positions[2]) /

--- a/test/testOldVoronoiGrid.cpp
+++ b/test/testOldVoronoiGrid.cpp
@@ -1652,9 +1652,10 @@ int main(int argc, char **argv) {
     }
     // add a random (small) displacement to one of the generators
     positions[42] += 1.e-5 * box_side * Utilities::random_position();
-    OldVoronoiGrid grid(positions, Box<>(CoordinateVector<>(box_anchor),
-                                         CoordinateVector<>(box_side)),
-                        false);
+    OldVoronoiGrid grid(
+        positions,
+        Box<>(CoordinateVector<>(box_anchor), CoordinateVector<>(box_side)),
+        false);
     grid.compute_grid();
 
     // print the grid while we have the grid connections

--- a/test/testSpatialAMRRefinementScheme.cpp
+++ b/test/testSpatialAMRRefinementScheme.cpp
@@ -50,9 +50,9 @@ int main(int argc, char **argv) {
       std::make_pair(0, grid.get_number_of_cells());
   grid.initialize(block, density_function);
 
-  assert_condition(grid.get_number_of_cells() ==
-                   8 * 8 * 8 - 4 * 4 * 4 + 8 * 8 * 8 - 6 * 6 * 6 +
-                       12 * 12 * 12);
+  assert_condition(grid.get_number_of_cells() == 8 * 8 * 8 - 4 * 4 * 4 +
+                                                     8 * 8 * 8 - 6 * 6 * 6 +
+                                                     12 * 12 * 12);
 
   return 0;
 }

--- a/test/testVernerCrossSections.cpp
+++ b/test/testVernerCrossSections.cpp
@@ -62,59 +62,69 @@ int main(int argc, char **argv) {
       double tolerance = 1.e-9;
 
       assert_values_equal_rel(
-          xsecH, UnitConverter::to_unit< QUANTITY_SURFACE_AREA >(
-                     cross_sections.get_cross_section(ION_H_n, e), "cm^2") *
-                     1.e18,
+          xsecH,
+          UnitConverter::to_unit< QUANTITY_SURFACE_AREA >(
+              cross_sections.get_cross_section(ION_H_n, e), "cm^2") *
+              1.e18,
           tolerance);
 
       assert_values_equal_rel(
-          xsecHe, UnitConverter::to_unit< QUANTITY_SURFACE_AREA >(
-                      cross_sections.get_cross_section(ION_He_n, e), "cm^2") *
-                      1.e18,
+          xsecHe,
+          UnitConverter::to_unit< QUANTITY_SURFACE_AREA >(
+              cross_sections.get_cross_section(ION_He_n, e), "cm^2") *
+              1.e18,
           tolerance);
 
       assert_values_equal_rel(
-          xsecCp1, UnitConverter::to_unit< QUANTITY_SURFACE_AREA >(
-                       cross_sections.get_cross_section(ION_C_p1, e), "cm^2") *
-                       1.e18,
+          xsecCp1,
+          UnitConverter::to_unit< QUANTITY_SURFACE_AREA >(
+              cross_sections.get_cross_section(ION_C_p1, e), "cm^2") *
+              1.e18,
           tolerance);
       assert_values_equal_rel(
-          xsecCp2, UnitConverter::to_unit< QUANTITY_SURFACE_AREA >(
-                       cross_sections.get_cross_section(ION_C_p2, e), "cm^2") *
-                       1.e18,
-          tolerance);
-
-      assert_values_equal_rel(
-          xsecN, UnitConverter::to_unit< QUANTITY_SURFACE_AREA >(
-                     cross_sections.get_cross_section(ION_N_n, e), "cm^2") *
-                     1.e18,
-          tolerance);
-      assert_values_equal_rel(
-          xsecNp1, UnitConverter::to_unit< QUANTITY_SURFACE_AREA >(
-                       cross_sections.get_cross_section(ION_N_p1, e), "cm^2") *
-                       1.e18,
-          tolerance);
-      assert_values_equal_rel(
-          xsecNp2, UnitConverter::to_unit< QUANTITY_SURFACE_AREA >(
-                       cross_sections.get_cross_section(ION_N_p2, e), "cm^2") *
-                       1.e18,
+          xsecCp2,
+          UnitConverter::to_unit< QUANTITY_SURFACE_AREA >(
+              cross_sections.get_cross_section(ION_C_p2, e), "cm^2") *
+              1.e18,
           tolerance);
 
       assert_values_equal_rel(
-          xsecO, UnitConverter::to_unit< QUANTITY_SURFACE_AREA >(
-                     cross_sections.get_cross_section(ION_O_n, e), "cm^2") *
-                     1.e18,
+          xsecN,
+          UnitConverter::to_unit< QUANTITY_SURFACE_AREA >(
+              cross_sections.get_cross_section(ION_N_n, e), "cm^2") *
+              1.e18,
           tolerance);
       assert_values_equal_rel(
-          xsecOp1, UnitConverter::to_unit< QUANTITY_SURFACE_AREA >(
-                       cross_sections.get_cross_section(ION_O_p1, e), "cm^2") *
-                       1.e18,
+          xsecNp1,
+          UnitConverter::to_unit< QUANTITY_SURFACE_AREA >(
+              cross_sections.get_cross_section(ION_N_p1, e), "cm^2") *
+              1.e18,
+          tolerance);
+      assert_values_equal_rel(
+          xsecNp2,
+          UnitConverter::to_unit< QUANTITY_SURFACE_AREA >(
+              cross_sections.get_cross_section(ION_N_p2, e), "cm^2") *
+              1.e18,
           tolerance);
 
       assert_values_equal_rel(
-          xsecNe, UnitConverter::to_unit< QUANTITY_SURFACE_AREA >(
-                      cross_sections.get_cross_section(ION_Ne_n, e), "cm^2") *
-                      1.e18,
+          xsecO,
+          UnitConverter::to_unit< QUANTITY_SURFACE_AREA >(
+              cross_sections.get_cross_section(ION_O_n, e), "cm^2") *
+              1.e18,
+          tolerance);
+      assert_values_equal_rel(
+          xsecOp1,
+          UnitConverter::to_unit< QUANTITY_SURFACE_AREA >(
+              cross_sections.get_cross_section(ION_O_p1, e), "cm^2") *
+              1.e18,
+          tolerance);
+
+      assert_values_equal_rel(
+          xsecNe,
+          UnitConverter::to_unit< QUANTITY_SURFACE_AREA >(
+              cross_sections.get_cross_section(ION_Ne_n, e), "cm^2") *
+              1.e18,
           tolerance);
       assert_values_equal_rel(
           xsecNep1,
@@ -124,19 +134,22 @@ int main(int argc, char **argv) {
           tolerance);
 
       assert_values_equal_rel(
-          xsecSp1, UnitConverter::to_unit< QUANTITY_SURFACE_AREA >(
-                       cross_sections.get_cross_section(ION_S_p1, e), "cm^2") *
-                       1.e18,
+          xsecSp1,
+          UnitConverter::to_unit< QUANTITY_SURFACE_AREA >(
+              cross_sections.get_cross_section(ION_S_p1, e), "cm^2") *
+              1.e18,
           tolerance);
       assert_values_equal_rel(
-          xsecSp2, UnitConverter::to_unit< QUANTITY_SURFACE_AREA >(
-                       cross_sections.get_cross_section(ION_S_p2, e), "cm^2") *
-                       1.e18,
+          xsecSp2,
+          UnitConverter::to_unit< QUANTITY_SURFACE_AREA >(
+              cross_sections.get_cross_section(ION_S_p2, e), "cm^2") *
+              1.e18,
           tolerance);
       assert_values_equal_rel(
-          xsecSp3, UnitConverter::to_unit< QUANTITY_SURFACE_AREA >(
-                       cross_sections.get_cross_section(ION_S_p3, e), "cm^2") *
-                       1.e18,
+          xsecSp3,
+          UnitConverter::to_unit< QUANTITY_SURFACE_AREA >(
+              cross_sections.get_cross_section(ION_S_p3, e), "cm^2") *
+              1.e18,
           tolerance);
     }
   }


### PR DESCRIPTION
## Description of the new code

Made the code compatible with Ubuntu 18.04 systems.

## Impact of the new code

Ubuntu 18.04 ships with Boost > 1.63.0, which means that the Boost Python NumPy libraries changed drastically (and caused compilation errors when the Python libraries were active). To address this, I disabled the Python libraries for Boost versions < 1.63.0 and rewrote the Python modules to use the new syntax. The new modules should work (they pass the unit tests), but have not been extensively tested.

Other changes are less drastic: I had to upgrade the formatting script to use a more recent version of `clang-format` and reformat (which caused a lot of formatting changes), and I had to add some additional comment blocks to satisfy a more pedantic `doxygen` version.