### PR TITLE
Pegase spectrum fix

### DIFF
--- a/benchmarks/bondi.py
+++ b/benchmarks/bondi.py
@@ -36,7 +36,7 @@ import h5py
 import matplotlib
 
 matplotlib.use("Agg")
-import pylab as pl
+import matplotlib.pyplot as pl
 
 # load the lambert W function, as the analytic solution uses it
 import scipy.special.lambertw as lambertw

--- a/benchmarks/dusty_galaxy.py
+++ b/benchmarks/dusty_galaxy.py
@@ -32,7 +32,10 @@
 import numpy as np
 
 # for plotting
-import pylab as pl
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as pl
 
 # load the binary file
 image = np.fromfile("galaxy_image.dat", dtype=np.float64)

--- a/benchmarks/lexingtonHII20.py
+++ b/benchmarks/lexingtonHII20.py
@@ -38,9 +38,12 @@
 # import some modules
 import numpy as np
 import h5py
-import pylab as pl
 import glob
 import scipy.stats as stats
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as pl
 
 ##
 # @brief Bin the given quantity in the given radial bins.

--- a/benchmarks/lexingtonHII40.py
+++ b/benchmarks/lexingtonHII40.py
@@ -39,9 +39,12 @@
 # import some modules
 import numpy as np
 import h5py
-import pylab as pl
 import glob
 import scipy.stats as stats
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as pl
 
 ##
 # @brief Bin the given quantity in the given radial bins.

--- a/benchmarks/starbench.py
+++ b/benchmarks/starbench.py
@@ -37,7 +37,7 @@ import h5py
 import matplotlib
 
 matplotlib.use("Agg")
-import pylab as pl
+import matplotlib.pyplot as pl
 import glob
 
 # set some plot options

--- a/benchmarks/starbench_voronoi.py
+++ b/benchmarks/starbench_voronoi.py
@@ -37,7 +37,7 @@ import h5py
 import matplotlib
 
 matplotlib.use("Agg")
-import pylab as pl
+import matplotlib.pyplot as pl
 import glob
 
 # set some plot options

--- a/benchmarks/stromgren.py
+++ b/benchmarks/stromgren.py
@@ -34,8 +34,11 @@
 import numpy as np
 import h5py
 import scipy.stats as stats
-import pylab as pl
 import glob
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as pl
 
 pl.rcParams["text.usetex"] = True
 

--- a/benchmarks/stromgren_diffuse.py
+++ b/benchmarks/stromgren_diffuse.py
@@ -34,8 +34,11 @@
 import numpy as np
 import h5py
 import scipy.stats as stats
-import pylab as pl
 import glob
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as pl
 
 pl.rcParams["text.usetex"] = True
 

--- a/src/Pegase3PhotonSourceSpectrum.cpp
+++ b/src/Pegase3PhotonSourceSpectrum.cpp
@@ -206,7 +206,8 @@ Pegase3PhotonSourceSpectrum::Pegase3PhotonSourceSpectrum(
         (file_frequencies[i2 + 1] - file_frequencies[i2]);
     double e2 = file_eddington_fluxes[i2] +
                 f * (file_eddington_fluxes[i2 + 1] - file_eddington_fluxes[i2]);
-    _cumulative_distribution[i] = 0.5 * (e1 / y2 + e2 / y1) * (y2 - y1);
+    _cumulative_distribution[i] =
+        0.5 * (e1 / (y2 * y2) + e2 / (y1 * y1)) * (y2 - y1);
   }
 
   // _cumulative_distribution now contains the actual ionizing spectrum

--- a/test/testPegase3PhotonSourceSpectrum.cpp
+++ b/test/testPegase3PhotonSourceSpectrum.cpp
@@ -47,8 +47,9 @@ double Pegase3spectrum(double *nuarr, double *earr, double nu) {
   while (nu > nuarr[inu]) {
     ++inu;
   }
-  return earr[inu - 1] / nuarr[inu - 1] +
-         (earr[inu] / nuarr[inu] - earr[inu - 1] / nuarr[inu - 1]) *
+  return earr[inu - 1] / (nuarr[inu - 1] * nuarr[inu - 1]) +
+         (earr[inu] / (nuarr[inu] * nuarr[inu]) -
+          earr[inu - 1] / (nuarr[inu - 1] * nuarr[inu - 1])) *
              (nu - nuarr[inu - 1]) / (nuarr[inu] - nuarr[inu - 1]);
 }
 
@@ -74,9 +75,9 @@ int main(int argc, char **argv) {
     RandomGenerator random_generator;
 
     const std::string agefile =
-        Pegase3PhotonSourceSpectrum::get_filename(1.e10, 0.02);
+        Pegase3PhotonSourceSpectrum::get_filename(1.e6, 0.02);
     assert_condition(agefile == PEGASE3DATALOCATION
-                     "pegase3_Z02_chab_059.spec");
+                     "pegase3_Z02_chab_002.spec");
     // read in the test spectrum
     std::ifstream ifile(agefile);
     std::string line;
@@ -95,7 +96,7 @@ int main(int argc, char **argv) {
     }
 
     std::ofstream file("Pegase3.txt");
-    Pegase3PhotonSourceSpectrum spectrum(1.e10, 0.02);
+    Pegase3PhotonSourceSpectrum spectrum(1.e6, 0.02);
 
     uint_fast32_t counts[1001];
     for (uint_fast32_t i = 0; i < 1001; ++i) {


### PR DESCRIPTION
## Description of the new code

The Pegase3PhotonSourceSpectrum contained a physics error: while the Pegase-3 data files contain a luminosity spectrum, the interpolation method used to read it and put it on the internal grid assumed a spectrum in luminosity/frequency. There was hence a missing 1/frequency factor.

Also changed the `matplotlib` imports in the benchmark tests; all of them still included `pylab` instead of `matplotlib.pyplot`, and some of them still used the default backend, while the `Agg` backend is preferred.

## Impact of the new code

Functionality did not change. Pegase-3 spectra were wrong before, and should be correct now.