### PR TITLE
Fixed Pegase-3 spectrum (again). This time it should work properly.

### DIFF
--- a/test/testPegase3PhotonSourceSpectrum.cpp
+++ b/test/testPegase3PhotonSourceSpectrum.cpp
@@ -47,9 +47,8 @@ double Pegase3spectrum(double *nuarr, double *earr, double nu) {
   while (nu > nuarr[inu]) {
     ++inu;
   }
-  return earr[inu - 1] / (nuarr[inu - 1] * nuarr[inu - 1]) +
-         (earr[inu] / (nuarr[inu] * nuarr[inu]) -
-          earr[inu - 1] / (nuarr[inu - 1] * nuarr[inu - 1])) *
+  return earr[inu - 1] / nuarr[inu - 1] +
+         (earr[inu] / nuarr[inu] - earr[inu - 1] / nuarr[inu - 1]) *
              (nu - nuarr[inu - 1]) / (nuarr[inu] - nuarr[inu - 1]);
 }
 
@@ -89,6 +88,8 @@ int main(int argc, char **argv) {
       getline(ifile, line);
       std::istringstream lstream(line);
       lstream >> nuarr[2380 - i] >> earr[2380 - i];
+      // convert from luminosity per wavelength to luminosity per frequency
+      earr[2380 - i] *= nuarr[2380 - i] * nuarr[2380 - i];
       // convert from Angstrom to Rydberg
       nuarr[2380 - i] = PhysicalConstants::get_physical_constant(
                             PHYSICALCONSTANT_LIGHTSPEED) *


### PR DESCRIPTION
## Description of the new code

Turns out the Pegase-3 spectrum fix in the previous pull request was not correct. Finally managed to get my head around this, and now it is definitely okay.

## Impact of the new code

As before, the old Pegase3PhotonSourceSpectrum did not work correctly (the spectrum was a lot harder than it should be). This has been fixed, and now the spectrum is very similar to the other stellar spectra in the code in terms of hardness.