### PR TITLE
Added minimum ionized temperature parameter for TemperatureCalculator.

### DIFF
--- a/src/TemperatureCalculator.hpp
+++ b/src/TemperatureCalculator.hpp
@@ -104,6 +104,10 @@ private:
    *  before computing the temperature. */
   const uint_fast32_t _minimum_iteration_number;
 
+  /*! @brief Temperature limit below which gas is assumed to be neutral
+   *  (in K). */
+  const double _minimum_ionized_temperature;
+
   /*! @brief Log to write logging info to. */
   Log *_log;
 
@@ -113,6 +117,7 @@ public:
       double luminosity, const Abundances &abundances,
       double epsilon_convergence, uint_fast32_t maximum_number_of_iterations,
       double pahfac, double crfac, double crlim, double crscale,
+      const double minimum_ionized_temperature,
       const LineCoolingData &line_cooling_data,
       const RecombinationRates &recombination_rates,
       const ChargeTransferRates &charge_transfer_rates, Log *log = nullptr);

--- a/test/testTemperatureCalculator.cpp
+++ b/test/testTemperatureCalculator.cpp
@@ -80,7 +80,7 @@ int main(int argc, char **argv) {
     ChargeTransferRates ctr;
     Abundances abundances(0.1, 2.2e-4, 4.e-5, 3.3e-4, 5.e-5, 9.e-6);
     TemperatureCalculator calculator(true, 3, 1., abundances, 1.e-3, 100, 1.,
-                                     0., 1., 0., data, rates, ctr);
+                                     0., 1., 0., 4000., data, rates, ctr);
 
     HomogeneousDensityFunction function(1.);
     function.initialize();
@@ -330,7 +330,8 @@ int main(int argc, char **argv) {
     ChargeTransferRates ctr;
     Abundances abundances(0.1, 2.2e-4, 4.e-5, 3.3e-4, 5.e-5, 9.e-6);
     TemperatureCalculator calculator(true, 3, 1., abundances, 1.e-3, 100, 1.,
-                                     1., 0.75, 4.11e19, data, rates, ctr);
+                                     1., 0.75, 4.11e19, 4000., data, rates,
+                                     ctr);
 
     DiscDensityFunction function;
     function.initialize();


### PR DESCRIPTION
## Description of the new code

Added an additional parameter to TemperatureCalculator that allows to change the temperature below which gas is assumed to be neutral. The old value was hardcoded to 4000 K, which turns out to be too high for some of the uniform box test cases I am currently running.

## Impact of the new code

An additional parameter (`minimum ionized temperature`) was added to TemperatureCalculator. The default value of this parameter (4000 K) reproduces the old behaviour.