### PR TITLE
Made sure duplicate positions are removed from SPHNGVoronoiGeneratorDistribution

### DIFF
--- a/src/SPHNGVoronoiGeneratorDistribution.cpp
+++ b/src/SPHNGVoronoiGeneratorDistribution.cpp
@@ -303,6 +303,13 @@ SPHNGVoronoiGeneratorDistribution::SPHNGVoronoiGeneratorDistribution(
     }
   }
 
+  // filter out duplicate positions
+  std::sort(_generator_positions.begin(), _generator_positions.end(),
+            position_smaller_than);
+  auto last =
+      std::unique(_generator_positions.begin(), _generator_positions.end());
+  _generator_positions.erase(last, _generator_positions.end());
+
   if (log) {
     log->write_info("position size: ", _generator_positions.size());
     log->write_info("number of particles: ", numpart);

--- a/src/SPHNGVoronoiGeneratorDistribution.hpp
+++ b/src/SPHNGVoronoiGeneratorDistribution.hpp
@@ -47,6 +47,45 @@ private:
   std::vector< CoordinateVector<> > _generator_positions;
 
 public:
+  /**
+   * @brief Comparison function for two 3D positions.
+   *
+   * We will use the following rules to decide if a position
+   * @$fa=(a_x,a_y,a_z)@f$ is smaller than a position @$fb=(b_x,b_y,b_z)@f$:
+   *  - the position is smaller if @f$a_x<b_x@f$,
+   *  - if @f$a_x=b_x@f$, then it is smaller if @f$a_y<b_y@f$,
+   *  - if @f$a_y=b_y@f$, then it is smaller if @f$a_z<b_z@f$,
+   *  - if @f$a_z=b_z@f$, we assume it is larger.
+   *
+   * @param a Position @f$a@f$.
+   * @param b Position @f$b@f$.
+   * @return True if @f$a<b@f$, according to the rules above.
+   */
+  inline static bool position_smaller_than(const CoordinateVector<> &a,
+                                           const CoordinateVector<> &b) {
+    if (a.x() < b.x()) {
+      return true;
+    } else {
+      if (a.x() == b.x()) {
+        if (a.y() < b.y()) {
+          return true;
+        } else {
+          if (a.y() == b.y()) {
+            if (a.z() < b.z()) {
+              return true;
+            } else {
+              return false;
+            }
+          } else {
+            return false;
+          }
+        }
+      } else {
+        return false;
+      }
+    }
+  }
+
   SPHNGVoronoiGeneratorDistribution(std::string filename, Log *log = nullptr);
 
   /**

--- a/src/SPHVoronoiGeneratorDistribution.hpp
+++ b/src/SPHVoronoiGeneratorDistribution.hpp
@@ -49,9 +49,6 @@ private:
   /*! @brief Number of positions already generated. */
   generatornumber_t _current_number;
 
-  /*! @brief Box containing the generators (in m). */
-  const Box<> _box;
-
   /*! @brief Name of ASCII file used to import Voronoi generating sites from. */
   std::string _filename;
 
@@ -62,17 +59,15 @@ public:
   /**
    * @brief Constructor.
    *
-   * @param simulation_box Simulation box (in m).
    * @param number_of_positions Number of SPH generator positions to
    * generate.
    * @param filename Name of the ASCII text file to read.
    * @param log Log to write logging info to.
    */
-  SPHVoronoiGeneratorDistribution(const Box<> &simulation_box,
-                                  generatornumber_t number_of_positions,
+  SPHVoronoiGeneratorDistribution(generatornumber_t number_of_positions,
                                   std::string filename, Log *log = nullptr)
       : _number_of_positions(number_of_positions), _current_number(0),
-        _box(simulation_box), _filename(filename) {
+        _filename(filename) {
 
     _generator_positions.resize(number_of_positions);
 
@@ -123,14 +118,11 @@ public:
    *  - number of positions: Number of positions in the file (default: 1000)
    *  - filename: Name of the file (default: SPH.txt)
    *
-   * @param simulation_box Simulation box (in m).
    * @param params ParameterFile to read from.
    * @param log Log to write logging info to.
    */
-  SPHVoronoiGeneratorDistribution(const Box<> &simulation_box,
-                                  ParameterFile &params, Log *log = nullptr)
+  SPHVoronoiGeneratorDistribution(ParameterFile &params, Log *log = nullptr)
       : SPHVoronoiGeneratorDistribution(
-            simulation_box,
             params.get_value< generatornumber_t >(
                 "DensityGrid:VoronoiGeneratorDistribution:number of positions",
                 1000),

--- a/src/VoronoiGeneratorDistributionFactory.hpp
+++ b/src/VoronoiGeneratorDistributionFactory.hpp
@@ -109,7 +109,7 @@ public:
                                                                 params, log);
     } else if (type == "SPH") {
       // added by Maya
-      return new SPHVoronoiGeneratorDistribution(simulation_box, params, log);
+      return new SPHVoronoiGeneratorDistribution(params, log);
     } else if (type == "SPHNG") {
       // added by Maya
       return new SPHNGVoronoiGeneratorDistribution(params, log);

--- a/test/testSPHNGSnapshotDensityFunction.cpp
+++ b/test/testSPHNGSnapshotDensityFunction.cpp
@@ -50,9 +50,7 @@ int main(int argc, char **argv) {
                                                   0, 0., 0., "");
     density_function.initialize();
 
-    SPHNGVoronoiGeneratorDistribution generator_distribution("SPHNGtest.dat",
-                                                             nullptr);
-
+    std::vector< CoordinateVector<> > positions;
     std::ifstream file("SPHNG_data.txt");
     std::string line;
     uint_fast32_t index = 0;
@@ -80,12 +78,20 @@ int main(int argc, char **argv) {
       assert_values_equal_rel(h, density_function.get_smoothing_length(index),
                               tolerance);
 
-      const CoordinateVector<> p2 = generator_distribution.get_position();
-      assert_values_equal_rel(x, p2.x(), tolerance);
-      assert_values_equal_rel(y, p2.y(), tolerance);
-      assert_values_equal_rel(z, p2.z(), tolerance);
+      positions.push_back(p);
 
       ++index;
+    }
+
+    std::sort(positions.begin(), positions.end(),
+              SPHNGVoronoiGeneratorDistribution::position_smaller_than);
+    SPHNGVoronoiGeneratorDistribution generator_distribution("SPHNGtest.dat",
+                                                             nullptr);
+    for (uint_fast32_t i = 0; i < positions.size(); ++i) {
+      const CoordinateVector<> p = generator_distribution.get_position();
+      assert_condition(positions[i].x() == p.x());
+      assert_condition(positions[i].y() == p.y());
+      assert_condition(positions[i].z() == p.z());
     }
     cmac_status("Done reading tagged file.");
   }
@@ -97,9 +103,7 @@ int main(int argc, char **argv) {
                                                   false, 0, 0., 0., "");
     density_function.initialize();
 
-    SPHNGVoronoiGeneratorDistribution generator_distribution(
-        "SPHNGtest_notags.dat", nullptr);
-
+    std::vector< CoordinateVector<> > positions;
     std::ifstream file("SPHNG_data.txt");
     std::string line;
     uint_fast32_t index = 0;
@@ -127,12 +131,20 @@ int main(int argc, char **argv) {
       assert_values_equal_rel(h, density_function.get_smoothing_length(index),
                               tolerance);
 
-      const CoordinateVector<> p2 = generator_distribution.get_position();
-      assert_values_equal_rel(x, p2.x(), tolerance);
-      assert_values_equal_rel(y, p2.y(), tolerance);
-      assert_values_equal_rel(z, p2.z(), tolerance);
+      positions.push_back(p);
 
       ++index;
+    }
+
+    std::sort(positions.begin(), positions.end(),
+              SPHNGVoronoiGeneratorDistribution::position_smaller_than);
+    SPHNGVoronoiGeneratorDistribution generator_distribution(
+        "SPHNGtest_notags.dat", nullptr);
+    for (uint_fast32_t i = 0; i < positions.size(); ++i) {
+      const CoordinateVector<> p = generator_distribution.get_position();
+      assert_condition(positions[i].x() == p.x());
+      assert_condition(positions[i].y() == p.y());
+      assert_condition(positions[i].z() == p.z());
     }
     cmac_status("Done reading untagged file.");
   }


### PR DESCRIPTION
## Description of the new code

The current `SPHNGVoronoiGeneratorDistribution` assumes that all positions in the SPHNG snapshot are well-behaved, i.e. are unique. If this is not the case, the Voronoi grid construction will fail. The fix introduced by this pull request fixes this by explicitly removing duplicate positions.