### PR TITLE
Changed the generic parameters-usedvalues.param file name

### DIFF
--- a/src/IonizationSimulation.cpp
+++ b/src/IonizationSimulation.cpp
@@ -216,12 +216,12 @@ IonizationSimulation::IonizationSimulation(const bool write_output,
   // now output all parameters (also those for which default values were used)
   // to a reference parameter file (only rank 0 does this)
   if (write_output) {
-    std::ofstream pfile(output_folder + "/parameters-usedvalues.param");
+    const std::string usedvaluename = parameterfile + ".used-values";
+    std::ofstream pfile(usedvaluename);
     _parameter_file.print_contents(pfile);
     pfile.close();
     if (_log) {
-      _log->write_status("Wrote used parameters to ", output_folder,
-                         "/parameters-usedvalues.param.");
+      _log->write_status("Wrote used parameters to ", usedvaluename, ".");
     }
   }
 

--- a/src/RadiationHydrodynamicsSimulation.cpp
+++ b/src/RadiationHydrodynamicsSimulation.cpp
@@ -376,12 +376,13 @@ int RadiationHydrodynamicsSimulation::do_simulation(CommandLineParser &parser,
   // now output all parameters (also those for which default values were used)
   // to a reference parameter file (only rank 0 does this)
   if (write_output && restart_reader == nullptr) {
-    std::ofstream pfile(output_folder + "/parameters-usedvalues.param");
+    const std::string usedvaluename =
+        parser.get_value< std::string >("params") + ".used-values";
+    std::ofstream pfile(usedvaluename);
     params->print_contents(pfile);
     pfile.close();
     if (log) {
-      log->write_status("Wrote used parameters to ", output_folder,
-                        "/parameters-usedvalues.param.");
+      log->write_status("Wrote used parameters to ", usedvaluename, ".");
     }
   }
 

--- a/src/TaskBasedIonizationSimulation.cpp
+++ b/src/TaskBasedIonizationSimulation.cpp
@@ -458,12 +458,12 @@ TaskBasedIonizationSimulation::TaskBasedIonizationSimulation(
 
   // we are done reading the parameter file
   // now output all parameters (also those for which default values were used)
-  std::ofstream pfile(output_folder + "/parameters-usedvalues.param");
+  const std::string usedvaluename = parameterfile_name + ".used-values";
+  std::ofstream pfile(usedvaluename);
   _parameter_file.print_contents(pfile);
   pfile.close();
   if (_log) {
-    _log->write_status("Wrote used parameters to ", output_folder,
-                       "/parameters-usedvalues.param.");
+    _log->write_status("Wrote used parameters to ", usedvaluename, ".");
   }
 
   _memory_log.add_entry("parameters done");

--- a/src/TaskBasedRadiationHydrodynamicsSimulation.cpp
+++ b/src/TaskBasedRadiationHydrodynamicsSimulation.cpp
@@ -1157,12 +1157,13 @@ int TaskBasedRadiationHydrodynamicsSimulation::do_simulation(
   // now output all parameters (also those for which default values were used)
   // to a reference parameter file (only rank 0 does this)
   if (write_output && restart_reader == nullptr) {
-    std::ofstream pfile(output_folder + "/parameters-usedvalues.param");
+    const std::string usedvaluename =
+        parser.get_value< std::string >("params") + ".used-values";
+    std::ofstream pfile(usedvaluename);
     params->print_contents(pfile);
     pfile.close();
     if (log) {
-      log->write_status("Wrote used parameters to ", output_folder,
-                        "/parameters-usedvalues.param.");
+      log->write_status("Wrote used parameters to ", usedvaluename, ".");
     }
   }
 


### PR DESCRIPTION
## Description of the new code

Until now, the code would produce a dump of the parameters as they were used in a generic file called `parameters-usedvalues.param` in the output folder for the simulation. This is very useful, but the generic name of the file is annoying for simulations that share an output folder, since then only one file will be present, depending on the order in which the simulations were run. To overcome this, the name of the file was changed to `ORIGINAL_NAME.used-values`, like was already done for the emission line calculator subprogram.

## Impact of the new code

The old `parameters-usedvalues.param` file no longer exists, so applications that use it should switch to the new naming convention.