### PR TITLE
Fixed possible issue in NewVoronoiCellConstructor.

### DIFF
--- a/src/NewVoronoiCellConstructor.hpp
+++ b/src/NewVoronoiCellConstructor.hpp
@@ -97,7 +97,7 @@ private:
     }
     _tetrahedra_size = new_size;
 
-    if (_tetrahedra_size == _tetrahedra.size()) {
+    if (_tetrahedra_size >= _tetrahedra.size()) {
       _tetrahedra.resize(_tetrahedra_size + NEWVORONOICELL_TETRAHEDRA_SIZE);
     }
   }
@@ -126,7 +126,7 @@ private:
     }
     _tetrahedra_size = new_size;
 
-    if (_tetrahedra_size == _tetrahedra.size()) {
+    if (_tetrahedra_size >= _tetrahedra.size()) {
       _tetrahedra.resize(_tetrahedra_size + NEWVORONOICELL_TETRAHEDRA_SIZE);
     }
   }


### PR DESCRIPTION
## Description of the new code

Small fix in NewVoronoiCellConstructor: when allocating new tetrahedra, the relevant check could fail if the number of tetrahedra that needed to be allocated was larger than 1.
