### PR TITLE
Made sure code compiles if HDF5 is not available.

### DIFF
--- a/src/CMacIonize.cpp
+++ b/src/CMacIonize.cpp
@@ -180,7 +180,9 @@ int main(int argc, char **argv) {
 
   // add simulation type specific parameters
   RadiationHydrodynamicsSimulation::add_command_line_parameters(parser);
+#ifdef HAVE_HDF5
   EmissivityCalculationSimulation::add_command_line_parameters(parser);
+#endif
   TaskBasedRadiationHydrodynamicsSimulation::add_command_line_parameters(
       parser);
 
@@ -285,11 +287,20 @@ int main(int argc, char **argv) {
                                                            programtimer, log);
   } else if (parser.get_value< bool >("emission")) {
 
+#ifdef HAVE_HDF5
+
     if (comm.get_size() > 1) {
       cmac_error("MPI emission calculation is not supported!");
     }
     return EmissivityCalculationSimulation::do_simulation(parser, write_output,
                                                           programtimer, log);
+
+#else
+    cmac_error("Code was not compiled with HDF5 support, emissivity calculator "
+               "will not work!");
+    return 1;
+#endif
+
   } else if (parser.get_value< bool >("task-based")) {
 
     if (comm.get_size() > 1) {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -123,7 +123,6 @@ configure_file(${PROJECT_SOURCE_DIR}/src/ConfigurationInfo.hpp.in
                ${PROJECT_BINARY_DIR}/src/ConfigurationInfo.hpp @ONLY)
 
 set(LIBIONIZATIONSIMULATION_SOURCES
-    AmunSnapshotDensityFunction.cpp
     AsciiFileDensityFunction.cpp
     AsciiFileDensityGridWriter.cpp
     AsciiFileTablePhotonSourceDistribution.cpp
@@ -169,6 +168,7 @@ set(LIBIONIZATIONSIMULATION_SOURCES
 )
 if(HAVE_HDF5)
   list(APPEND LIBIONIZATIONSIMULATION_SOURCES
+       ../src/AmunSnapshotDensityFunction.cpp
        ../src/CMacIonizeSnapshotDensityFunction.cpp
        ../src/CMacIonizeVoronoiGeneratorDistribution.cpp
        ../src/FLASHSnapshotDensityFunction.cpp
@@ -187,7 +187,6 @@ set(CMACIONIZE_SOURCES
     DeRijckeRadiativeCooling.cpp
     DustScattering.cpp
     DustSimulation.cpp
-    EmissivityCalculationSimulation.cpp
     EmissivityCalculator.cpp
     RadiationHydrodynamicsSimulation.cpp
     Signals.cpp
@@ -196,7 +195,6 @@ set(CMACIONIZE_SOURCES
     Abundances.hpp
     AMRRefinementScheme.hpp
     AMRRefinementSchemeFactory.hpp
-    AmunSnapshotDensityFunction.cpp
     AsciiFileDensityFunction.hpp
     AsciiFileDensityGridWriter.hpp
     AsciiFileTablePhotonSourceDistribution.hpp
@@ -204,8 +202,6 @@ set(CMACIONIZE_SOURCES
     BondiProfileDensityFunction.hpp
     CartesianDensityGrid.hpp
     ChargeTransferRates.hpp
-    CMacIonizeSnapshotDensityFunction.hpp
-    CMacIonizeVoronoiGeneratorDistribution.hpp
     Configuration.hpp.in
     ConfigurationInfo.hpp.in
     ContinuousPhotonSourceFactory.hpp
@@ -296,11 +292,7 @@ set_source_files_properties(${PROJECT_BINARY_DIR}/src/CompilerInfo.cpp
 # add HDF5 dependent sources, if we have found HDF5
 if(HAVE_HDF5)
     list(APPEND CMACIONIZE_SOURCES
-        FLASHSnapshotDensityFunction.hpp
-        GadgetDensityGridWriter.hpp
-        GadgetSnapshotDensityFunction.hpp
-        GadgetSnapshotPhotonSourceDistribution.hpp
-        HDF5Tools.hpp)
+         EmissivityCalculationSimulation.cpp)
 endif(HAVE_HDF5)
 
 if(HAVE_WINDOWS)
@@ -333,18 +325,13 @@ endif(HAVE_MPI)
 
 set(LIBTASKBASEDIONIZATIONSIMULATION_SOURCES
 
-    AmunSnapshotDensityFunction.cpp
     AsciiFileDensityFunction.cpp
     AsciiFileTablePhotonSourceDistribution.cpp
     AtomicValue.hpp
     ChargeTransferRates.cpp
-    CMacIonizeSnapshotDensityFunction.cpp
     CPUCycle.hpp
     DensitySubGrid.hpp
     FaucherGiguerePhotonSourceSpectrum.cpp
-    FLASHSnapshotDensityFunction.cpp
-    GadgetSnapshotDensityFunction.cpp
-    GadgetSnapshotPhotonSourceDistribution.cpp
     HeliumLymanContinuumSpectrum.cpp
     HeliumTwoPhotonContinuumSpectrum.cpp
     HydrogenLymanContinuumSpectrum.cpp
@@ -375,6 +362,17 @@ set(LIBTASKBASEDIONIZATIONSIMULATION_SOURCES
     VernerRecombinationRates.cpp
     WMBasicPhotonSourceSpectrum.cpp
 )
+
+# add HDF5 dependent sources, if we have found HDF5
+if(HAVE_HDF5)
+    list(APPEND LIBTASKBASEDIONIZATIONSIMULATION_SOURCES
+        AmunSnapshotDensityFunction.cpp
+        CMacIonizeSnapshotDensityFunction.cpp
+        FLASHSnapshotDensityFunction.cpp
+        GadgetSnapshotDensityFunction.cpp
+        GadgetSnapshotPhotonSourceDistribution.cpp
+        HDF5Tools.hpp)
+endif(HAVE_HDF5)
 
 add_library(TaskBasedIonizationSimulation ${LIBTASKBASEDIONIZATIONSIMULATION_SOURCES})
 add_dependencies(TaskBasedIonizationSimulation CompilerInfo)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1561,13 +1561,16 @@ set(TESTTASKBASEDIONIZATIONSIMULATION_SOURCES
     testTaskBasedIonizationSimulation.cpp
 
     ../src/AsciiFileDensityGridWriter.cpp
-    ../src/GadgetDensityGridWriter.cpp
     ../src/ParameterFile.cpp
     ../src/Signals.cpp
 
     ${PROJECT_BINARY_DIR}/src/CompilerInfo.cpp
     ${PROJECT_BINARY_DIR}/src/ConfigurationInfo.cpp
 )
+if(HAVE_HDF5)
+  list(APPEND TESTTASKBASEDIONIZATIONSIMULATION_SOURCES
+       ../src/GadgetDensityGridWriter.cpp)
+endif(HAVE_HDF5)
 set_source_files_properties(${PROJECT_BINARY_DIR}/src/CompilerInfo.cpp
                             PROPERTIES GENERATED TRUE)
 add_unit_test(NAME testTaskBasedIonizationSimulation


### PR DESCRIPTION
## Description of the new code

Due to bad maintenance and incomplete CI, the code no longer compiled on systems that do not have the HDF5 library available. This was fixed.

## Impact of the new code

The code should now compile again on systems that do not have HDF5.