### PR TITLE
Added accumulators to compute average queue size.

### DIFF
--- a/src/TaskBasedIonizationSimulation.cpp
+++ b/src/TaskBasedIonizationSimulation.cpp
@@ -1732,12 +1732,18 @@ void TaskBasedIonizationSimulation::run(
       _shared_queue->reset_total_queue_size();
       ofile << "    max: " << _shared_queue->get_max_queue_size() << "\n";
       _shared_queue->reset_max_queue_size();
+      ofile << "    average: " << _shared_queue->get_average_queue_size()
+            << "\n";
+      _shared_queue->reset_average_queue_size();
       for (uint_fast32_t i = 0; i < _queues.size(); ++i) {
         ofile << "  thread " << i << ":\n";
         ofile << "    total: " << _queues[i]->get_total_queue_size() << "\n";
         _queues[i]->reset_total_queue_size();
         ofile << "    max: " << _queues[i]->get_max_queue_size() << "\n";
         _queues[i]->reset_max_queue_size();
+        ofile << "    average: " << _queues[i]->get_average_queue_size()
+              << "\n";
+        _queues[i]->reset_average_queue_size();
       }
       ofile << "threads:\n";
       for (uint_fast32_t i = 0; i < thread_stats.size(); ++i) {

--- a/tools/plot_memory.py
+++ b/tools/plot_memory.py
@@ -52,14 +52,17 @@ data = np.loadtxt(
 memsum = data["virtual size"].sum()
 data = data[data["virtual size"] > 0.01 * memsum]
 
+labels = []
 # convert sizes to MB
 for row in data:
-    row["label"] += " ({0:.0f} MB)".format(float(row["virtual size"]) / MB)
+    labels.append(
+        "{0} ({1:.0f} MB)".format(
+            row["label"].decode("utf-8"), float(row["virtual size"]) / MB
+        )
+    )
 
 # create the pie chart
-pl.pie(
-    data["virtual size"], explode=np.ones(len(data)) * 0.1, labels=data["label"]
-)
+pl.pie(data["virtual size"], explode=np.ones(len(data)) * 0.1, labels=labels)
 
 # put the total memory usage in the title
 pl.title("Total memory: {0:.0f} MB".format(memsum / MB))

--- a/tools/write_parameterfile.py
+++ b/tools/write_parameterfile.py
@@ -1,0 +1,148 @@
+#! /usr/bin/python
+
+################################################################################
+# This file is part of CMacIonize
+# Copyright (C) 2020 Bert Vandenbroucke (bert.vandenbroucke@gmail.com)
+#
+# CMacIonize is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# CMacIonize is distributed in the hope that it will be useful,
+# but WITOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with CMacIonize. If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+##
+# @file write_parameterfile.py
+#
+# @brief Script that can be used to read and write CMacIonize parameter files.
+#
+# This script is meant to be imported from another script and makes available
+# the functions `read_parameterfile()` and `write_parameterfile` that can be
+# used to respectively parse the contents of a parameter file into a Python
+# dictionary, or write out the contents of a Python dictionary to a parameter
+# file. When used on its own, the script takes two required arguments, `input`
+# and `output`. In this case, the parameter file corresponding to `input` is
+# read in and then written out to `output`. This is only useful as a test.
+#
+# @author Bert Vandenbroucke (bert.vandenbroucke@ugent.be)
+##
+
+import sys
+import re
+import time
+import datetime
+
+
+# read the parameter file with the given name and return a dictionary containing
+# its contents
+def read_parameterfile(filename):
+    file = open(filename, "r")
+
+    params = {}
+    indent = 0
+    groupname = []
+    lines = 0
+    for line in file.readlines():
+        if line[0] == "#":
+            continue
+        m = re.match(r"(?P<indent>[ ]*)(?P<groupname>.*?):([ ]?#.*?)?$", line)
+        if m:
+            lines += 1
+            current_indent = len(m.group("indent"))
+            if current_indent > indent:
+                indent = current_indent
+            if current_indent < indent:
+                indent = current_indent
+                groupname.pop()
+            groupname.append(m.group("groupname"))
+        m = re.match(
+            r"(?P<indent>[ ]*)(?P<key>.*?):[ ]*" "(?P<value>.+?)[#\n]", line
+        )
+        if m:
+            lines += 1
+            current_indent = len(m.group("indent"))
+            if current_indent > indent:
+                indent = current_indent
+            if current_indent < indent:
+                indent = current_indent
+                groupname.pop()
+            groupname.append(m.group("key"))
+            full_name = ":".join(groupname)
+            groupname.pop()
+            params[full_name] = m.group("value").strip()
+
+    return params
+
+
+# write the given parameter dictionary to a new parameter file with the given
+# name
+def write_parameterfile(filename, params):
+    file = open(filename, "w")
+
+    timestamp = datetime.datetime.fromtimestamp(time.time()).strftime(
+        "%d/%m/%Y, %H:%M:%S"
+    )
+    file.write(
+        "# file automatically written by write_parameterfile.py on "
+        "{timestamp}\n".format(timestamp=timestamp)
+    )
+
+    groupname = []
+    stream = ""
+    for key in sorted(params):
+        keygroups = key.split(":")
+        keyname = keygroups[-1]
+        keygroups.pop()
+        indent = ""
+        if len(keygroups) > len(groupname):
+            i = 0
+            while i < len(groupname) and groupname[i] == keygroups[i]:
+                i += 1
+            for j in range(i):
+                indent += "  "
+            for j in range(i, len(groupname)):
+                groupname.pop()
+            for j in range(i, len(keygroups)):
+                groupname.append(keygroups[j])
+                stream += indent + keygroups[j] + ":\n"
+                indent += "  "
+        else:
+            while len(keygroups) < len(groupname):
+                groupname.pop()
+            i = 0
+            while i < len(keygroups) and groupname[i] == keygroups[i]:
+                i += 1
+            for j in range(i):
+                indent += "  "
+            for j in range(i, len(keygroups)):
+                groupname.pop()
+            for j in range(i, len(keygroups)):
+                groupname.append(keygroups[j])
+                stream += indent + keygroups[j] + ":\n"
+                indent += "  "
+
+        stream += indent + keyname + ": " + params[key] + "\n"
+
+    file.write(stream)
+
+
+# unit test the read and write functions
+if __name__ == "__main__":
+    import argparse
+
+    argparser = argparse.ArgumentParser(
+        "Copy the given input parameter file into the given output by reading it into a Python dictionary and writing out that dictionary again."
+    )
+    argparser.add_argument("--input", "-i", action="store", required=True)
+    argparser.add_argument("--output", "-o", action="store", required=True)
+    args = argparser.parse_args()
+
+    params = read_parameterfile(args.input)
+    write_parameterfile(args.output, params)


### PR DESCRIPTION
## Description of the new code

Right now, the only diagnostic output for task queues is the maximum number of tasks at any given moment and the total number of tasks stored. A more interesting/useful quantity is the average number of tasks stored in the queue. Added accumulators to compute this. Not sure my current definition of the average is sensible: each addition or retrieval from the queue counts as an event, and the average is taken over all events. For the Lexington benchmark, this consistently gives average queues sizes below 1... Will think about this more before I merge.

## Impact of the new code

Queues take a bit more memory now and additional output is written to the diagnostic output files. Only relevant for task-based post-processing simulations.