### PR TITLE
Made sure photon shooting timer works properly.

### DIFF
--- a/src/TaskBasedIonizationSimulation.cpp
+++ b/src/TaskBasedIonizationSimulation.cpp
@@ -1781,10 +1781,11 @@ void TaskBasedIonizationSimulation::run(
     stop_parallel_timing_block();
     _time_log.end("copy update");
 
+    _worktimer.stop();
+
     if (_task_plot) {
       _time_log.start("task output");
       cpucycle_tick(iteration_end);
-      _worktimer.stop();
       output_tasks(iloop, *_tasks, iteration_start, iteration_end);
       output_queues(iloop, _queues, *_shared_queue);
       _time_log.end("task output");


### PR DESCRIPTION
## Description of the new code

The timer that is supposed to quantify how much time is spent propagating photons (so doing actual useful work, as opposed to doing setup and I/O) was not working properly for the task-based algorithm: it only output a non-zero time value if task plot output was enabled. This was wrong and was fixed.

## Impact of the new code

The photon shooting time now always contains a non-zero value when the task-based algorithm is used, regardless of how the task-based algorithm is run.