### PR TITLE
Made sure cell tracker is properly initialized during restart.

### DIFF
--- a/src/IonizationVariables.hpp
+++ b/src/IonizationVariables.hpp
@@ -454,6 +454,7 @@ public:
       _heating[i] = restart_reader.read< double >();
     }
     _cosmic_ray_factor = restart_reader.read< double >();
+    _tracker = nullptr;
   }
 
   /**


### PR DESCRIPTION
## Description of the new code

The cell tracker variable was not initialized properly in the restart constructor of `IonizationVariables`, causing a segfault on restart.

## Impact of the new code

Restarting runs (both with the task-based and old algorithm) now works again.