### PR TITLE
Fixed a bug with the momentum being erratically zeroed out based on the unused energy variable during isothermal runs. Only affects the old RHD algorithm.

### DIFF
--- a/src/HydroIntegrator.hpp
+++ b/src/HydroIntegrator.hpp
@@ -1398,8 +1398,10 @@ public:
 #ifdef SAFE_HYDRO
       it.get_hydro_variables().conserved(4) =
           std::max(it.get_hydro_variables().get_conserved_total_energy(), 0.);
-      if (it.get_hydro_variables().get_conserved_total_energy() == 0.) {
-        it.get_hydro_variables().set_conserved_momentum(0.);
+      if(_gamma > 1.){
+        if (it.get_hydro_variables().get_conserved_total_energy() == 0.) {
+          it.get_hydro_variables().set_conserved_momentum(0.);
+        }
       }
 #else
       cmac_assert(_gamma == 1. ||


### PR DESCRIPTION
## Description of the new code

One of the safety checks for the old hydro algorithm zeroes out the momentum of a cell if that cell's energy is zero. This is just a safety measure to avoid material fluxing out of cells that do not contain any material. Unfortunately, this check was not correctly disabled for isothermal runs. In an isothermal run, the energy is ignored, and can have arbitrary values (because of laziness, the energy variable still receives some work contributions). In other words: a variable that is not part of the hydro could potentially zero out the momentum in an unpredictable fashion.

## Impact of the new code

The impact of the bug on simulations run with the old code is hard to assess, since it depends a lot on how the energy still changes. At a first glance, it looks like the isothermal energy only contains contributions from the gravitational potential, in which case the problem would mostly occur in the presence of strong gravitational accelerations. This is also how the bug was discovered. The new code fixes this issue completely, and is now fully consistent with the new task-based RHD algorithm. The bug was introduced in e1b2dad3b9ba377b3f28e47b67205f3345f2638d.