### PR TITLE
Github Actions CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,10 +21,6 @@ jobs:
         os: [ubuntu-18.04, ubuntu-20.04]
         hdf5: [true, false]
         compiler: [gcc, clang]
-        # exclude HDF5 builds with Clang
-        exclude:
-          - compiler: clang
-            hdf5: true
         # Set the C and C++ compiler names for the given compiler family
         include:
           - compiler: gcc

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to help you get started with Actions
 
-name: CI
+name: Automated build and unit tests
 
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events but only for the master branch
@@ -15,7 +15,11 @@ jobs:
   # This workflow contains a single job called "build"
   build:
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04]
+        with_hdf5: ["true", "false"]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -23,6 +27,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Install dependencies
+      if: ${{ matrix.with_hdf5 }} == "true"
       run: |
         sudo apt install libhdf5-dev
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,6 @@ on:
 jobs:
   # Build and test the code
   build:
-    name: Build and test the code
     # The type of runner that the job will run on
     runs-on: ${{ matrix.os }}
     # Matrix of systems, HDF5/no HDF5 and GCC/Clang
@@ -51,8 +50,6 @@ jobs:
         cd $GITHUB_WORKSPACE
         mkdir build
         cd build
-        which ${{ matrix.cc }}
-        which ${{ matrix.cpp }}
         cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=${{ matrix.cc }} -DCMAKE_CXX_COMPILER=${{ matrix.cpp }} ..
         
     - name: Compile
@@ -76,7 +73,6 @@ jobs:
 
   # check code formatting
   formatting:
-    name: Formatting
     runs-on: ubuntu-18.04
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,8 +18,16 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04]
-        hdf5: [true, false]
+        os: [ubuntu-20.04]
+        hdf5: [true]
+        compiler: [gcc, clang]
+        include:
+          - compiler: gcc
+            cc: gcc
+            cpp: g++
+          - compiler: clang
+            cc: clang-9.0
+            cpp: clang++-9.0
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -37,7 +45,7 @@ jobs:
         cd $GITHUB_WORKSPACE
         mkdir build
         cd build
-        cmake -DCMAKE_BUILD_TYPE=Release ..
+        cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=${{ matrix.cc }} -DCMAKE_CXX_COMPILER=${{ matrix.cpp }} ..
         
     - name: Compile
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,14 +20,14 @@ jobs:
       matrix:
         os: [ubuntu-20.04]
         hdf5: [true]
-        compiler: [gcc, clang]
+        compiler: [clang]
         include:
           - compiler: gcc
             cc: gcc
             cpp: g++
           - compiler: clang
-            cc: clang-9.0
-            cpp: clang++-9.0
+            cc: clang
+            cpp: clang++
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -45,6 +45,8 @@ jobs:
         cd $GITHUB_WORKSPACE
         mkdir build
         cd build
+        which ${{ matrix.cc }}
+        which ${{ matrix.cpp }}
         cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=${{ matrix.cc }} -DCMAKE_CXX_COMPILER=${{ matrix.cpp }} ..
         
     - name: Compile

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,10 @@ jobs:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
 
+    - name: Install dependencies
+      run: |
+        sudo apt install libhdf5-dev
+
     # Runs a single command using the runners shell
     - name: Configure
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,26 +1,32 @@
-# This is a basic workflow to help you get started with Actions
+# Script for the automatic build and unit testing
 
 name: Automated build and unit tests
 
-# Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the master branch
+# Action triggers for all pushes and pull requests on the master branch
 on:
   push:
     branches: [ master ]
   pull_request:
     branches: [ master ]
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+# List of jobs to run
 jobs:
-  # This workflow contains a single job called "build"
+  # Build and test the code
   build:
+    name: Build and test the code
     # The type of runner that the job will run on
     runs-on: ${{ matrix.os }}
+    # Matrix of systems, HDF5/no HDF5 and GCC/Clang
     strategy:
       matrix:
-        os: [ubuntu-20.04]
-        hdf5: [true]
-        compiler: [clang]
+        os: [ubuntu-18.04, ubuntu-20.04]
+        hdf5: [true, false]
+        compiler: [gcc, clang]
+        # exclude HDF5 builds with Clang
+        exclude:
+          - compiler: clang
+            hdf5: true
+        # Set the C and C++ compiler names for the given compiler family
         include:
           - compiler: gcc
             cc: gcc
@@ -37,7 +43,7 @@ jobs:
     - name: Install dependencies
       if: matrix.hdf5
       run: |
-        sudo apt install libhdf5-dev
+        sudo apt-get install libhdf5-dev
 
     # Runs a single command using the runners shell
     - name: Configure
@@ -67,3 +73,24 @@ jobs:
         cd $GITHUB_WORKSPACE
         cd build
         make check -j4
+
+  # check code formatting
+  formatting:
+    name: Formatting
+    runs-on: ubuntu-18.04
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        run: |
+          sudo apt-get install clang-format-6.0
+      - name: Check formatting
+        run: |
+          cd $GITHUB_WORKSPACE
+          ./format_script.sh
+          if ! git diff --no-ext-diff --quiet --exit-code; then
+            echo "Code not correctly formatted!"
+            exit 1
+          else
+            echo "Code format check passed."
+          fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,39 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+
+    # Runs a single command using the runners shell
+    - name: Configure
+      run: |
+        cd $GITHUB_WORKSPACE
+        mkdir build
+        cd build
+        cmake -DCMAKE_BUILD_TYPE=Release ..
+        
+    - name: Compile
+      run: |
+        make -j4
+    
+    - name: Unit tests
+      run: |
+        make check -j4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04]
-        with_hdf5: ["true", "false"]
+        hdf5: [true, false]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -27,7 +27,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Install dependencies
-      if: ${{ matrix.with_hdf5 }} == "true"
+      if: matrix.hdf5
       run: |
         sudo apt install libhdf5-dev
 
@@ -45,7 +45,14 @@ jobs:
         cd build
         make -j4
     
-    - name: Unit tests
+    - name: Compile unit tests
+      run: |
+        cd $GITHUB_WORKSPACE
+        cd build
+        make buildTests -j4
+    
+    - name: Run unit tests
+      if: matrix.hdf5
       run: |
         cd $GITHUB_WORKSPACE
         cd build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,8 +32,12 @@ jobs:
         
     - name: Compile
       run: |
+        cd $GITHUB_WORKSPACE
+        cd build
         make -j4
     
     - name: Unit tests
       run: |
+        cd $GITHUB_WORKSPACE
+        cd build
         make check -j4


### PR DESCRIPTION
Set up Continuous Integration (CI) using Github Actions. This replaces the existing Travis CI.