### PR TITLE
Some tracker fixes

### DIFF
--- a/src/TaskBasedIonizationSimulation.cpp
+++ b/src/TaskBasedIonizationSimulation.cpp
@@ -1013,7 +1013,7 @@ void TaskBasedIonizationSimulation::run(
     cmac_assert_message(_buffers->is_empty(), "Number of active buffers: %zu",
                         _buffers->get_number_of_active_buffers());
 
-    if (_trackers != nullptr) {
+    if (_trackers != nullptr && iloop == _number_of_iterations - 1) {
       _trackers->normalize(_total_luminosity / _number_of_photons);
     }
 

--- a/src/WeightedSpectrumTracker.hpp
+++ b/src/WeightedSpectrumTracker.hpp
@@ -112,9 +112,13 @@ public:
    * weight (in s^-1).
    */
   virtual void normalize(const double luminosity_per_weight) {
+
+    cmac_assert_message(_side_length > 0., "Tracker was not normalized!");
+
+    const double norm = luminosity_per_weight / (_side_length * _side_length);
     for (int_fast32_t i = 0; i < PHOTONTYPE_NUMBER; ++i) {
       for (uint_fast32_t j = 0; j < _number_counts[i].size(); ++j) {
-        _number_counts[i][j] *= luminosity_per_weight;
+        _number_counts[i][j] *= norm;
       }
     }
   }
@@ -281,14 +285,20 @@ public:
 
     const double frequency = photon.get_energy();
     const size_t index = _frequency_bins->get_bin_number(frequency);
-    const double weight = get_projected_area(photon.get_direction()) *
-                          _side_length * _side_length;
+
+    cmac_assert(index >= 0);
+    cmac_assert(index < _number_counts[0].size());
+
+    const double weight = get_projected_area(photon.get_direction());
 
     cmac_assert_message(weight == weight, "direction: %g %g %g",
                         photon.get_direction().x(), photon.get_direction().y(),
                         photon.get_direction().z());
 
-    _number_counts[photon.get_type()][index] += 1. / weight;
+    const double inverse_weight = 1. / weight;
+    cmac_assert(!std::isinf(inverse_weight));
+
+    _number_counts[photon.get_type()][index] += inverse_weight;
   }
 
   /**
@@ -305,14 +315,20 @@ public:
 
     const double frequency = photon.get_energy();
     const size_t index = _frequency_bins->get_bin_number(frequency);
-    const double weight = get_projected_area(photon.get_direction()) *
-                          _side_length * _side_length;
+
+    cmac_assert(index >= 0);
+    cmac_assert(index < _number_counts[0].size());
+
+    const double weight = get_projected_area(photon.get_direction());
 
     cmac_assert_message(weight == weight, "direction: %g %g %g",
                         photon.get_direction().x(), photon.get_direction().y(),
                         photon.get_direction().z());
 
-    _number_counts[photon.get_type()][index] += 1. / weight;
+    const double inverse_weight = 1. / weight;
+    cmac_assert(!std::isinf(inverse_weight));
+
+    _number_counts[photon.get_type()][index] += inverse_weight;
   }
 
   /**

--- a/src/WeightedSpectrumTracker.hpp
+++ b/src/WeightedSpectrumTracker.hpp
@@ -285,7 +285,8 @@ public:
                           _side_length * _side_length;
 
     cmac_assert_message(weight == weight, "direction: %g %g %g",
-                        photon.get_direction());
+                        photon.get_direction().x(), photon.get_direction().y(),
+                        photon.get_direction().z());
 
     _number_counts[photon.get_type()][index] += 1. / weight;
   }
@@ -308,7 +309,8 @@ public:
                           _side_length * _side_length;
 
     cmac_assert_message(weight == weight, "direction: %g %g %g",
-                        photon.get_direction());
+                        photon.get_direction().x(), photon.get_direction().y(),
+                        photon.get_direction().z());
 
     _number_counts[photon.get_type()][index] += 1. / weight;
   }

--- a/src/WeightedSpectrumTracker.hpp
+++ b/src/WeightedSpectrumTracker.hpp
@@ -283,6 +283,9 @@ public:
     const size_t index = _frequency_bins->get_bin_number(frequency);
     const double weight = get_projected_area(photon.get_direction()) *
                           _side_length * _side_length;
+
+    cmac_assert(weight == weight);
+
     _number_counts[photon.get_type()][index] += 1. / weight;
   }
 

--- a/src/WeightedSpectrumTracker.hpp
+++ b/src/WeightedSpectrumTracker.hpp
@@ -284,7 +284,8 @@ public:
     const double weight = get_projected_area(photon.get_direction()) *
                           _side_length * _side_length;
 
-    cmac_assert(weight == weight);
+    cmac_assert_message(weight == weight, "direction: %g %g %g",
+                        photon.get_direction());
 
     _number_counts[photon.get_type()][index] += 1. / weight;
   }
@@ -305,6 +306,10 @@ public:
     const size_t index = _frequency_bins->get_bin_number(frequency);
     const double weight = get_projected_area(photon.get_direction()) *
                           _side_length * _side_length;
+
+    cmac_assert_message(weight == weight, "direction: %g %g %g",
+                        photon.get_direction());
+
     _number_counts[photon.get_type()][index] += 1. / weight;
   }
 

--- a/test/testWeightedSpectrumTracker.cpp
+++ b/test/testWeightedSpectrumTracker.cpp
@@ -25,6 +25,7 @@
  */
 
 #include "Assert.hpp"
+#include "RandomGenerator.hpp"
 #include "WeightedSpectrumTracker.hpp"
 
 /**
@@ -84,6 +85,21 @@ int main(int argc, char **argv) {
     const double area = WeightedSpectrumTracker::get_projected_area(n);
     cmac_warning("area: %g", area);
     assert_values_equal_rel(area, std::sqrt(3), 1.e-16);
+  }
+
+  /// a bunch of random directions to make sure the result is always valid
+  {
+    RandomGenerator rg(42);
+    for (uint_fast32_t i = 0; i < 1e6; ++i) {
+      CoordinateVector<> direction(rg.get_uniform_random_double(),
+                                   rg.get_uniform_random_double(),
+                                   rg.get_uniform_random_double());
+      direction /= direction.norm();
+      const double area =
+          WeightedSpectrumTracker::get_projected_area(direction);
+      assert_condition(area > 0.);
+      assert_condition(area == area);
+    }
   }
 
   return 0;


### PR DESCRIPTION
## Description of the new code

Made sure the tracker normalisation function is only called during the final iteration (when trackers are active). Added additional assertions and a smarter normalisation to `WeightedSpectrumTracker`.

## Impact of the new code

New code should not affect performance, but might now actually crash if `NaN` values occur in the `WeightedSpectrumTracker`.