### PR TITLE
Memory issues

### DIFF
--- a/src/Error.hpp
+++ b/src/Error.hpp
@@ -49,7 +49,7 @@
     char line[65];                                                             \
     while (buffer[pos] != '\0') {                                              \
       if (buffer[pos] == '\n') {                                               \
-        fprintf(stream, "     %-65s\n", line);                                 \
+        fprintf(stream, "     %-65.65s\n", line);                              \
         ++pos;                                                                 \
         linepos = 0;                                                           \
       } else {                                                                 \
@@ -82,7 +82,7 @@
           ++linepos;                                                           \
         }                                                                      \
         if (linepos == 65) {                                                   \
-          fprintf(stream, "     %-65s\n", line);                               \
+          fprintf(stream, "     %-65.65s\n", line);                            \
           linepos = 0;                                                         \
         }                                                                      \
         ++pos;                                                                 \
@@ -90,7 +90,7 @@
     }                                                                          \
     if (linepos) {                                                             \
       line[linepos] = '\0';                                                    \
-      fprintf(stream, "     %-65s\n", line);                                   \
+      fprintf(stream, "     %-65.65s\n", line);                                \
     }                                                                          \
   }
 

--- a/src/UniformRandomPhotonSourceDistribution.hpp
+++ b/src/UniformRandomPhotonSourceDistribution.hpp
@@ -249,7 +249,12 @@ public:
   /**
    * @brief Virtual destructor.
    */
-  virtual ~UniformRandomPhotonSourceDistribution() {}
+  virtual ~UniformRandomPhotonSourceDistribution() {
+    if (_output_file) {
+      _output_file->close();
+      delete _output_file;
+    }
+  }
 
   /**
    * @brief Get the number of sources contained within this distribution.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1873,3 +1873,6 @@ add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND}
                                   --parallel ${MAX_NUMBER_OF_THREADS}
                                   --output-on-failure
                         DEPENDS ${TESTNAMES})
+add_custom_target(check_serial COMMAND ${CMAKE_CTEST_COMMAND}
+                                  --output-on-failure
+                               DEPENDS ${TESTNAMES})

--- a/test/testFLASHSnapshotDensityFunction.cpp
+++ b/test/testFLASHSnapshotDensityFunction.cpp
@@ -65,5 +65,7 @@ int main(int argc, char **argv) {
   }
   assert_values_equal(xi2, 0.0106294);
 
+  density.free();
+
   return 0;
 }


### PR DESCRIPTION
## Description of the new code

Discovered some issues while running the unit tests with Clang in debug mode. Fixed these. Also added a `check_serial` target for the unit tests that runs them in serial, as opposed to the default `check` target that runs them in parallel using the number of detected cores on the machine.

## Impact of the new code

The new fixed code should not change any of the old behaviour, although this was not explicitly tested (especially the changes to the `print_indent` macro could potentially lead to changes in the diagnostic output).