### PR TITLE
Automatic MultiTracker and other tracker fixes

### DIFF
--- a/src/AbsorptionTracker.hpp
+++ b/src/AbsorptionTracker.hpp
@@ -183,6 +183,10 @@ public:
    */
   virtual void create_group(const HDF5Tools::HDF5Group group,
                             const uint_fast32_t group_size) {
+
+    std::string type_string = "Absorption";
+    HDF5Tools::write_attribute< std::string >(group, "type", type_string);
+
     std::vector< std::string > ion_names(NUMBER_OF_IONNAMES);
     for (int_fast32_t i = 0; i < NUMBER_OF_IONNAMES; i++) {
       ion_names[i] = get_ion_name(i);

--- a/src/IonizationSimulation.cpp
+++ b/src/IonizationSimulation.cpp
@@ -276,16 +276,6 @@ void IonizationSimulation::initialize(DensityFunction *density_function) {
   }
 #endif
 
-  // check that the trackers can be sensibly placed within the grid
-  if (_trackers != nullptr) {
-    // add trackers
-    _trackers->add_trackers(*_density_grid);
-    // now remove them again, as we do not want to activate them just yet
-    for (auto it = _density_grid->begin(); it != _density_grid->end(); ++it) {
-      it.get_ionization_variables().add_tracker(nullptr);
-    }
-  }
-
   // _density_grid->initialize initialized:
   // - densities
   // - temperatures

--- a/src/MultiTracker.hpp
+++ b/src/MultiTracker.hpp
@@ -28,6 +28,7 @@
 
 #include "Tracker.hpp"
 
+#include <sstream>
 #include <vector>
 
 class Photon;
@@ -55,6 +56,34 @@ public:
 
   virtual ~MultiTracker();
 
+  /**
+   * @brief Add the given tracker to the list of stored trackers.
+   *
+   * @param tracker Tracker to add.
+   * @param name Name for this tracker (default: tracker X, where X is the index
+   * of this tracker in the list).
+   */
+  inline void add_tracker(Tracker *tracker, std::string name = "") {
+
+    if (name == "") {
+      std::stringstream namestr;
+      namestr << "tracker " << _trackers.size();
+      name = namestr.str();
+    }
+    _trackers.push_back(tracker);
+    _output_names.push_back(name);
+  }
+
+  /**
+   * @brief Erase the internally stored trackers to make sure they are not
+   * deleted twice.
+   */
+  inline void erase_trackers() {
+    for (uint_fast32_t i = 0; i < _trackers.size(); ++i) {
+      _trackers[i] = nullptr;
+    }
+  }
+
   virtual Tracker *duplicate();
   virtual void merge(Tracker *tracker);
 
@@ -63,6 +92,13 @@ public:
                             const double *absorption);
 
   virtual void output_tracker(const std::string filename) const;
+
+  /**
+   * @brief Is this tracker a MultiTracker?
+   *
+   * @return True.
+   */
+  virtual bool is_multi_tracker() const { return true; }
 };
 
 #endif // MULTITRACKER_HPP

--- a/src/Tracker.hpp
+++ b/src/Tracker.hpp
@@ -146,6 +146,13 @@ public:
    * @param stream std::ostream to write to.
    */
   virtual void describe(const std::string prefix, std::ostream &stream) const {}
+
+  /**
+   * @brief Is this tracker a MultiTracker?
+   *
+   * @return False.
+   */
+  virtual bool is_multi_tracker() const { return false; }
 };
 
 #endif // TRACKER_HPP

--- a/src/TrackerFactory.hpp
+++ b/src/TrackerFactory.hpp
@@ -30,6 +30,7 @@
 #include "YAMLDictionary.hpp"
 
 // implementations
+#include "AbsorptionTracker.hpp"
 #include "MultiTracker.hpp"
 #include "SpectrumTracker.hpp"
 #include "WeightedSpectrumTracker.hpp"
@@ -44,8 +45,10 @@ public:
    * YAMLDictionary.
    *
    * Supported types are:
+   *  - Absorption: Absorption tracker that tracks the absorption per ion in
+   *    each cell.
    *  - Multi: Dummy that allows attaching multiple trackers to a single cell.
-   *  - Spectrum: Spectrum tracker
+   *  - Spectrum: Spectrum tracker.
    *  - WeightedSpectrum: Spectrum tracker that weighs contributions according
    *    to the projected surface area for incoming photon packets.
    *
@@ -59,7 +62,9 @@ public:
 
     const std::string type = blocks.get_value< std::string >(name + "type");
 
-    if (type == "Multi") {
+    if (type == "Absorption") {
+      return new AbsorptionTracker(name, blocks);
+    } else if (type == "Multi") {
       return new MultiTracker(name, blocks);
     } else if (type == "Spectrum") {
       return new SpectrumTracker(name, blocks);


### PR DESCRIPTION
## Description of the new code

Until now, the code would crash if an attempt was made to add two different trackers to the same cell, unless the user manually created a MultiTracker. This process has now been automated, and is completely hidden from the user (so the additional MultiTracker will not show up in the tracker output).

## Impact of the new code

Multiple trackers can now be added to the same cell without any problem. IonizationSimulation (so the non task-based version) used to add the trackers to the grid before running a simulation, just to check that they were sensibly placed. This check has been removed. This puts a bit more responsibility in the hands of the user, since trackers outside the grid range will no longer be flagged until the final iteration. The existing AbsorptionTracker was now added to TrackerFactory, making it available from within the tracker parameter file.