### PR TITLE
Fixed MultiTracker bug

### DIFF
--- a/src/PhotonPacket.hpp
+++ b/src/PhotonPacket.hpp
@@ -178,6 +178,8 @@ public:
    */
   inline void set_direction(const CoordinateVector<> direction) {
     _direction = direction;
+    // make sure the direction is properly normalised
+    _direction /= _direction.norm();
   }
 
   /**

--- a/src/TrackerManager.hpp
+++ b/src/TrackerManager.hpp
@@ -269,10 +269,6 @@ public:
       auto copies = gridit.get_copies();
       bool first = true;
       for (auto copyit = copies.first; copyit != copies.second; ++copyit) {
-        IonizationVariables &ionization_variables =
-            (*copyit)
-                .get_cell(_tracker_positions[i])
-                .get_ionization_variables();
         Tracker *new_tracker = _trackers[i]->duplicate();
         _trackers.push_back(new_tracker);
         _originals.push_back(i);
@@ -280,7 +276,25 @@ public:
           _copies[i] = _trackers.size() - 1;
           first = false;
         }
-        ionization_variables.add_tracker(new_tracker);
+        IonizationVariables &ionization_variables =
+            (*copyit)
+                .get_cell(_tracker_positions[i])
+                .get_ionization_variables();
+        if (ionization_variables.get_tracker() != nullptr) {
+          MultiTracker *multi_tracker;
+          if (ionization_variables.get_tracker()->is_multi_tracker()) {
+            multi_tracker = static_cast< MultiTracker * >(
+                ionization_variables.get_tracker());
+          } else {
+            multi_tracker = new MultiTracker();
+            multi_tracker->add_tracker(ionization_variables.get_tracker());
+            ionization_variables.add_tracker(multi_tracker);
+            _multi_trackers.push_back(multi_tracker);
+          }
+          multi_tracker->add_tracker(_trackers[i]);
+        } else {
+          ionization_variables.add_tracker(_trackers[i]);
+        }
       }
     }
   }

--- a/src/WeightedSpectrumTracker.hpp
+++ b/src/WeightedSpectrumTracker.hpp
@@ -254,10 +254,13 @@ public:
         CoordinateVector<>::dot_product(p110_111, p110_011);
     const double p110_011_p110_010 =
         CoordinateVector<>::dot_product(p110_011, p110_010);
-    const double ay1 = std::sqrt(p110_111.norm2() * p110_011.norm2() -
-                                 p110_111_p110_011 * p110_111_p110_011);
-    const double ay2 = std::sqrt(p110_011.norm2() * p110_010.norm2() -
-                                 p110_011_p110_010 * p110_011_p110_010);
+    // make sure we don't get NaN
+    const double ay1_2 = p110_111.norm2() * p110_011.norm2() -
+                         p110_111_p110_011 * p110_111_p110_011;
+    const double ay1 = (ay1_2 > 0.) ? std::sqrt(ay1_2) : 0.;
+    const double ay2_2 = p110_011.norm2() * p110_010.norm2() -
+                         p110_011_p110_010 * p110_011_p110_010;
+    const double ay2 = (ay2_2 > 0.) ? std::sqrt(ay2_2) : 0.;
 
     const CoordinateVector<> p101_001 = p001 - p101;
     const CoordinateVector<> p101_011 = p011 - p101;
@@ -266,12 +269,22 @@ public:
         CoordinateVector<>::dot_product(p101_001, p101_011);
     const double p101_011_p101_111 =
         CoordinateVector<>::dot_product(p101_011, p101_111);
-    const double az1 = std::sqrt(p101_001.norm2() * p101_011.norm2() -
-                                 p101_001_p101_011 * p101_001_p101_011);
-    const double az2 = std::sqrt(p101_011.norm2() * p101_111.norm2() -
-                                 p101_011_p101_111 * p101_011_p101_111);
+    // make sure we don't get NaN
+    const double az1_2 = p101_001.norm2() * p101_011.norm2() -
+                         p101_001_p101_011 * p101_001_p101_011;
+    const double az1 = (az1_2 > 0.) ? std::sqrt(az1_2) : 0.;
+    const double az2_2 = p101_011.norm2() * p101_111.norm2() -
+                         p101_011_p101_111 * p101_011_p101_111;
+    const double az2 = (az2_2 > 0.) ? std::sqrt(az2_2) : 0.;
 
-    return 0.5 * (ax1 + ax2 + ay1 + ay2 + az1 + az2);
+    const double weight = 0.5 * (ax1 + ax2 + ay1 + ay2 + az1 + az2);
+
+    cmac_assert_message(
+        weight == weight, "direction: %g %g %g (%lu %lu %lu)", direction.x(),
+        direction.y(), direction.z(), Utilities::as_bytes(direction.x()),
+        Utilities::as_bytes(direction.y()), Utilities::as_bytes(direction.z()));
+
+    return weight;
   }
 
   /**
@@ -290,10 +303,6 @@ public:
     cmac_assert(index < _number_counts[0].size());
 
     const double weight = get_projected_area(photon.get_direction());
-
-    cmac_assert_message(weight == weight, "direction: %g %g %g",
-                        photon.get_direction().x(), photon.get_direction().y(),
-                        photon.get_direction().z());
 
     const double inverse_weight = 1. / weight;
     cmac_assert(!std::isinf(inverse_weight));
@@ -320,10 +329,6 @@ public:
     cmac_assert(index < _number_counts[0].size());
 
     const double weight = get_projected_area(photon.get_direction());
-
-    cmac_assert_message(weight == weight, "direction: %g %g %g",
-                        photon.get_direction().x(), photon.get_direction().y(),
-                        photon.get_direction().z());
 
     const double inverse_weight = 1. / weight;
     cmac_assert(!std::isinf(inverse_weight));

--- a/test/testWeightedSpectrumTracker.cpp
+++ b/test/testWeightedSpectrumTracker.cpp
@@ -91,9 +91,17 @@ int main(int argc, char **argv) {
   {
     RandomGenerator rg(42);
     for (uint_fast32_t i = 0; i < 1e6; ++i) {
-      CoordinateVector<> direction(rg.get_uniform_random_double(),
-                                   rg.get_uniform_random_double(),
-                                   rg.get_uniform_random_double());
+      // draw two pseudo random numbers
+      const double cost = 2. * rg.get_uniform_random_double() - 1.;
+      const double phi = 2. * M_PI * rg.get_uniform_random_double();
+
+      // now use them to get all directional angles
+      const double sint = std::sqrt(std::max(1. - cost * cost, 0.));
+      const double cosp = std::cos(phi);
+      const double sinp = std::sin(phi);
+
+      // set the direction...
+      CoordinateVector<> direction(sint * cosp, sint * sinp, cost);
       direction /= direction.norm();
       const double area =
           WeightedSpectrumTracker::get_projected_area(direction);


### PR DESCRIPTION
## Description of the new code

The automatic procedure to add MultiTrackers to cells that contain more than one tracker failed for the task-based distributed grid in the presence of subgrid copies. This has been fixed. During testing, a `NaN` weight was discovered in WeightedSpectrumTracker, so additional safeties were implemented to deal with this in the future.

## Impact of the new code

Bug was fixed, no negative impact expected.