### PR TITLE
Added cron schedule trigger for automatic unit tests.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,8 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  schedule:
+    - cron: '0 0 1 */1 *'
 
 # List of jobs to run
 jobs:


### PR DESCRIPTION
## Description of the new code

The current continuous integration approach assumes only code changes can trigger compilation and test issues. However, if the code is not changed for a long time, external changes (compiler updates...) could potentially cause problems too. This pull request adds a new trigger to the automatic unit tests that also schedules the testing workflow at midnight on the 1st of every month, so that the tests are at least run once a month.

## Impact of the new code

None. Only affects the continuous integration on github.