### PR TITLE
Fix for warnings after system update

### DIFF
--- a/src/CoordinateVector.hpp
+++ b/src/CoordinateVector.hpp
@@ -26,6 +26,8 @@
 #ifndef COORDINATEVECTOR_HPP
 #define COORDINATEVECTOR_HPP
 
+#include "Error.hpp"
+
 #include "RestartReader.hpp"
 #include "RestartWriter.hpp"
 
@@ -185,7 +187,10 @@ public:
    * @param i Index which we want to access.
    * @return Reference to the requested component.
    */
-  inline _datatype_ &operator[](uint_fast8_t i) { return _c[i]; }
+  inline _datatype_ &operator[](uint_fast8_t i) {
+    cmac_assert(i < 3);
+    return _c[i];
+  }
 
   /**
    * @brief Index operator. Get a const reference to the component at the given
@@ -194,7 +199,10 @@ public:
    * @param i Index which we want to access.
    * @return Const reference to the requested component.
    */
-  inline const _datatype_ &operator[](uint_fast8_t i) const { return _c[i]; }
+  inline const _datatype_ &operator[](uint_fast8_t i) const {
+    cmac_assert(i < 3);
+    return _c[i];
+  }
 
   /**
    * @brief Compare this CoordinateVector with another CoordinateVector.

--- a/src/HydroVariables.hpp
+++ b/src/HydroVariables.hpp
@@ -322,8 +322,8 @@ public:
       _conserved[i] = other._conserved[i];
       _delta_conserved[i] = other._delta_conserved[i];
       _primitive_gradients[i] = other._primitive_gradients[i];
-      _gravitational_acceleration[i] = other._gravitational_acceleration[i];
     }
+    _gravitational_acceleration = other._gravitational_acceleration;
 
     _energy_rate_term = other._energy_rate_term;
     _energy_term = other._energy_term;

--- a/src/MPICommunicator.hpp
+++ b/src/MPICommunicator.hpp
@@ -427,7 +427,6 @@ public:
    * @brief Reduce the given variable across all processes.
    *
    * @param value Variable to reduce.
-   * @return Reduced variable.
    */
   template < MPIOperatorType _operatortype_, typename _datatype_ >
   void reduce(_datatype_ &value) const {

--- a/src/NewVoronoiCellConstructor.cpp
+++ b/src/NewVoronoiCellConstructor.cpp
@@ -1011,8 +1011,6 @@ void NewVoronoiCellConstructor::n_to_2n_flip(uint_fast32_t new_vertex,
  * @param top1 Index of the vertex of the second tetrahedron opposite the first
  * tetrahedron.
  * @param tn Array to store the indices of the newly created tetrahedra in.
- * @return First tetrahedron in the stack that needs to be tested after the
- * flip.
  */
 void NewVoronoiCellConstructor::two_to_three_flip(uint_fast32_t tetrahedron0,
                                                   uint_fast32_t tetrahedron1,
@@ -1167,8 +1165,6 @@ void NewVoronoiCellConstructor::two_to_three_flip(uint_fast32_t tetrahedron0,
  * @param tetrahedron2 Third tetrahedron.
  * @param tetrahedron3 Fourth tetrahedron.
  * @param tn Array to store the indices of the newly created tetrahedra in.
- * @return First tetrahedron in the stack that needs to be tested after the
- * flip.
  */
 void NewVoronoiCellConstructor::four_to_four_flip(uint_fast32_t tetrahedron0,
                                                   uint_fast32_t tetrahedron1,
@@ -1380,8 +1376,6 @@ void NewVoronoiCellConstructor::four_to_four_flip(uint_fast32_t tetrahedron0,
  * @param tetrahedron1 Second tetrahedron.
  * @param tetrahedron2 Third tetrahedron.
  * @param tn Array to store the indices of the newly created tetrahedra in.
- * @return First tetrahedron in the stack that needs to be tested after the
- * flip.
  */
 void NewVoronoiCellConstructor::three_to_two_flip(uint_fast32_t tetrahedron0,
                                                   uint_fast32_t tetrahedron1,

--- a/src/SurfaceDensityCalculator.hpp
+++ b/src/SurfaceDensityCalculator.hpp
@@ -126,7 +126,6 @@ public:
    * @param number_of_subgrids Number of subgrids in each coordinate direction.
    * @param number_of_cells Number of cells per coordinate direction for a
    * single subgrid.
-   * @param number_of_cells
    */
   inline SurfaceDensityCalculator(
       const CoordinateVector< int_fast32_t > number_of_subgrids,

--- a/src/SurfaceDensityIonizedCalculator.hpp
+++ b/src/SurfaceDensityIonizedCalculator.hpp
@@ -149,7 +149,6 @@ public:
    * @param number_of_subgrids Number of subgrids in each coordinate direction.
    * @param number_of_cells Number of cells per coordinate direction for a
    * single subgrid.
-   * @param number_of_cells
    */
   inline SurfaceDensityIonizedCalculator(
       const CoordinateVector< int_fast32_t > number_of_subgrids,


### PR DESCRIPTION
## Description of the new code

GCC 10 and Doxygen 1.8.18 (and possibly older versions as well) flag a few issues that had gone unnoticed until now: an out-of-bounds access to the components of the gravitational acceleration vector in `HydroIntegrator` and some documentation issues in older files. These are solved by this pull request. This pull request also introduces assertions in `CoordinateVector` that should help flag these issues in the future.

## Impact of the new code

The out-of-bounds access issue is in a part of the code that was not used in production runs, and hence has no impact on existing results. The new assertions might have an impact on the runtime.