### PR TITLE
Lexicographical sort for command line option output

### DIFF
--- a/src/CommandLineOption.hpp
+++ b/src/CommandLineOption.hpp
@@ -29,6 +29,7 @@
 #include <cstdlib>
 #include <ostream>
 #include <string>
+#include <vector>
 
 /**
  * @brief Possible types of arguments for a command line option.
@@ -90,6 +91,19 @@ public:
   bool matches(std::string option) const;
   std::string parse_argument(std::string argument) const;
   std::string get_default_value() const;
+
+  /**
+   * @brief Comparison function that can be used to lexicographically sort
+   * command line options.
+   *
+   * @param a First command line option.
+   * @param b Second command line option.
+   * @return True if
+   */
+  inline static bool compare(const CommandLineOption &a,
+                             const CommandLineOption &b) {
+    return a.get_long_name().compare(b.get_long_name()) <= 0;
+  }
 };
 
 #endif // COMMANDLINEOPTION_HPP

--- a/src/CommandLineParser.cpp
+++ b/src/CommandLineParser.cpp
@@ -88,15 +88,24 @@ void CommandLineParser::add_option(std::string long_name, char short_name,
  * @param stream std::ostream to write to.
  */
 void CommandLineParser::print_description(std::ostream &stream) const {
+
+  std::vector< uint_fast32_t > idx(_options.size());
+  for (size_t i = 0; i < _options.size(); ++i) {
+    idx[i] = i;
+  }
+  std::sort(idx.begin(), idx.end(), [this](size_t i1, size_t i2) {
+    return CommandLineOption::compare(this->_options[i1], this->_options[i2]);
+  });
+
   stream << "Usage:\n\n";
   stream << "    " << _program_name;
-  for (auto it = _options.begin(); it != _options.end(); ++it) {
+  for (uint_fast32_t i = 0; i < _options.size(); ++i) {
     stream << " ";
-    it->print_usage(stream);
+    _options[idx[i]].print_usage(stream);
   }
   stream << "\n\nPossible options:\n\n";
-  for (auto it = _options.begin(); it != _options.end(); ++it) {
-    it->print_description(stream);
+  for (uint_fast32_t i = 0; i < _options.size(); ++i) {
+    _options[idx[i]].print_description(stream);
   }
 }
 


### PR DESCRIPTION
## Description of the new code

Made sure command line options are sorted lexicographically when outputting them with `--help` or equivalent.

## Impact of the new code

No real impact, although finding command line options in the `--help` list should now be easier.