### PR TITLE
Removed TASK_PLOT macro and duplicate command line options

### DIFF
--- a/src/RadiationHydrodynamicsSimulation.cpp
+++ b/src/RadiationHydrodynamicsSimulation.cpp
@@ -95,12 +95,14 @@
  */
 void RadiationHydrodynamicsSimulation::add_command_line_parameters(
     CommandLineParser &parser) {
-  parser.add_option("output-time-unit", 0,
-                    "Unit for time stat output to the terminal.",
-                    COMMANDLINEOPTION_STRINGARGUMENT, "s");
-  parser.add_option("restart", 0,
-                    "Restart from the restart file stored in the given folder.",
-                    COMMANDLINEOPTION_STRINGARGUMENT, ".");
+  // these options are now specified in
+  // TaskBasedRadiationHydrodynamicsSimulation::add_command_line_parameters()
+  //  parser.add_option("output-time-unit", 0,
+  //                    "Unit for time stat output to the terminal.",
+  //                    COMMANDLINEOPTION_STRINGARGUMENT, "s");
+  //  parser.add_option("restart", 0,
+  //                    "Restart from the restart file stored in the given
+  //                    folder.", COMMANDLINEOPTION_STRINGARGUMENT, ".");
 }
 
 /**

--- a/src/Task.hpp
+++ b/src/Task.hpp
@@ -26,9 +26,6 @@
 #ifndef TASK_HPP
 #define TASK_HPP
 
-/*! @brief Activate this to record the start and end time of each task. */
-#define TASK_PLOT
-
 #include "AtomicValue.hpp"
 #include "CPUCycle.hpp"
 #include "ThreadLock.hpp"
@@ -109,7 +106,6 @@ private:
   /*! @brief Dependencies (if any). */
   ThreadLock *_dependency[2];
 
-#ifdef TASK_PLOT
   /*! @brief Rank of the thread that executed the task. */
   int_least32_t _thread_id;
 
@@ -118,7 +114,6 @@ private:
 
   /*! @brief Time stamp for the end of the task. */
   uint_least64_t _end_time;
-#endif
 
 public:
   /**
@@ -127,11 +122,7 @@ public:
    * Used to flag unexecuted tasks and initialize the dependency.
    */
   Task() : _number_of_children(0), _dependency{nullptr, nullptr} {
-#ifdef TASK_PLOT
     _end_time = 0;
-#else
-    _type = TASKTYPE_NUMBER;
-#endif
   }
 
   /**
@@ -150,11 +141,7 @@ public:
     _dependency[0] = other._dependency[0];
     _dependency[1] = other._dependency[1];
 
-#ifdef TASK_PLOT
     _end_time = other._end_time;
-#else
-    _type = other._type;
-#endif
 
     return *this;
   }
@@ -165,38 +152,21 @@ public:
    * @param thread_id Thread that executes the task.
    */
   inline void start(const int_fast32_t thread_id) {
-#ifdef TASK_PLOT
     _thread_id = thread_id;
     cpucycle_tick(_start_time);
-#endif
   }
 
   /**
    * @brief Record the end time of the task.
    */
-  inline void stop() {
-#ifdef TASK_PLOT
-    cpucycle_tick(_end_time);
-#else
-    // we need another way to flag the end of the task
-    // since we do not care about what task this was (we don't plot it), we can
-    // overwrite the type variable
-    _type = -1;
-#endif
-  }
+  inline void stop() { cpucycle_tick(_end_time); }
 
   /**
    * @brief Check if the task was already done.
    *
    * @return True if the task was executed, false otherwise.
    */
-  inline bool done() const {
-#ifdef TASK_PLOT
-    return _end_time > 0;
-#else
-    return _type == -1;
-#endif
-  }
+  inline bool done() const { return _end_time > 0; }
 
   /**
    * @brief Set the dependency for the task.
@@ -372,7 +342,6 @@ public:
     _interaction_direction = interaction_direction;
   }
 
-#ifdef TASK_PLOT
   /**
    * @brief Get all information necessary to write the task to an output file.
    *
@@ -392,7 +361,6 @@ public:
     start = _start_time;
     end = _end_time;
   }
-#endif
 };
 
 #endif // TASK_HPP

--- a/src/TaskBasedRadiationHydrodynamicsSimulation.cpp
+++ b/src/TaskBasedRadiationHydrodynamicsSimulation.cpp
@@ -707,7 +707,7 @@ execute_task(const size_t itask,
  *    for time values that are written to the Log (default: s).
  *  - restart (no abbreviation, optional, string argument): restart a run from
  *    the restart file stored in the given folder (default: .).
- *  - task-plot (no abbreviation, optional, integer argument): output task
+ *  - task-plot-rhd (no abbreviation, optional, integer argument): output task
  *    information for the first N steps of the algorithm (default: 0).
  *  - number-of-steps (no abbreviation, optional, integer argument): number of
  *    time steps to execute before halting the code (negative values mean no
@@ -725,7 +725,7 @@ void TaskBasedRadiationHydrodynamicsSimulation::add_command_line_parameters(
                     "Restart from the restart file stored in the given folder.",
                     COMMANDLINEOPTION_STRINGARGUMENT, ".");
   parser.add_option(
-      "task-plot", 0,
+      "task-plot-rhd", 0,
       "Output task information for the first N steps of the algorithm",
       COMMANDLINEOPTION_INTARGUMENT, "0");
   parser.add_option("number-of-steps", 0,
@@ -936,7 +936,7 @@ int TaskBasedRadiationHydrodynamicsSimulation::do_simulation(
       parser.get_value< std::string >("output-time-unit");
 
   const int_fast32_t task_plot_N =
-      parser.get_value< int_fast32_t >("task-plot");
+      parser.get_value< int_fast32_t >("task-plot-rhd");
 
   const int_fast32_t number_of_steps =
       parser.get_value< int_fast32_t >("number-of-steps");

--- a/test/testTaskQueue.cpp
+++ b/test/testTaskQueue.cpp
@@ -27,9 +27,6 @@
 /*! @brief Number of tasks used during the test. */
 #define TESTTASKQUEUE_NTASK 10000
 
-/*! @brief Make sure we output the task plot for the unit test. */
-#define TASK_PLOT
-
 #include "Assert.hpp"
 #include "TaskQueue.hpp"
 #include "ThreadSafeVector.hpp"


### PR DESCRIPTION
## Description of the new code

For historical reasons, the ability to output task plots was configurable by defining a macro `TASK_PLOT` in `Task.hpp`. The main reason was that task plots require additional time stamps to be stored in the task, and this could have impact on code performance.
However, since such an impact was in fact never really observed, and since the task-based RHD algorithm crucially depends on it being defined (otherwise hydro tasks could not be reused, since their type would have been erased by `Task::stop()`), this posed a potential risk. The `TASK_PLOT` macro has been removed, and its functionality is now no longer configurable.

This pull request also (finally) addresses the duplicate command line options that had been present since the addition of a task-based RHD algorithm. Since the assumption is that the task-based algorithm will some day become default, the duplicate options were removed from the old algorithm.
This is more than an aesthetic fix; as it turned out the duplicate `--task-plot` option had been defined with different types. As a result, the task-based RHD version of this option did in fact not work. This has been addressed by renaming the RHD option, it is now called `--task-plot-rhd`.

## Impact of the new code

It is no longer possible to disable task plots manually by commenting out a macro in `Task.hpp`. It seems unlikely that anyone used this functionality.

The `--task-plot` option for task-based RHD runs has been replaced with an option called `--task-plot-rhd`. Contrary to the previous version, this option now also actually works.