### PR TITLE
M1 fixes

### DIFF
--- a/src/BufferedCMacIonizeSnapshotDensityFunction.hpp
+++ b/src/BufferedCMacIonizeSnapshotDensityFunction.hpp
@@ -440,7 +440,7 @@ public:
   inline uint_fast32_t buffer_subgrid(const uint_fast32_t subgrid_index) {
 
     // sort the buffers according to their last access time
-    const std::vector< uint_fast32_t > buffer_timestamps_copy(
+    const std::vector< uint_fast64_t > buffer_timestamps_copy(
         _buffer_timestamps);
     const std::vector< uint_fast32_t > timesort =
         Utilities::argsort(buffer_timestamps_copy);

--- a/src/CPUCycle.hpp
+++ b/src/CPUCycle.hpp
@@ -1,6 +1,7 @@
 /*******************************************************************************
  * This file is part of CMacIonize
  * Copyright (C) 2018 Bert Vandenbroucke (bert.vandenbroucke@gmail.com)
+ *               2021 Bert Vandenbroucke
  *
  * CMacIonize is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -31,11 +32,16 @@
  *
  * @param time_variable Variable to store the result in.
  */
+#if defined(__x86_64__) || defined(__amd64__)
 #define cpucycle_tick(time_variable)                                           \
   {                                                                            \
     unsigned int lo, hi;                                                       \
     __asm__ __volatile__("rdtsc" : "=a"(lo), "=d"(hi));                        \
     time_variable = ((unsigned long)hi << 32) | lo;                            \
   }
+#else
+#define cpucycle_tick(time_variable)                                           \
+  { time_variable = 0; }
+#endif
 
 #endif // CPUCYCLE_HPP

--- a/src/PhotonPacketStatistics.hpp
+++ b/src/PhotonPacketStatistics.hpp
@@ -69,7 +69,7 @@ public:
    * @param packet photon packet retrieved to be terminated
    */
   inline void absorb_photon(const PhotonPacket &packet) {
-    uint_fast32_t scatter_counter = packet.get_scatter_counter();
+    size_t scatter_counter = packet.get_scatter_counter();
     _scatter_histogram[std::min(scatter_counter, _scatter_histogram.size() - 1)]
         .pre_increment();
   }
@@ -79,7 +79,7 @@ public:
    * @param packet Photon packet.
    */
   inline void escape_photon(const PhotonPacket &packet) {
-    uint_fast32_t scatter_counter = packet.get_scatter_counter();
+    size_t scatter_counter = packet.get_scatter_counter();
     _scatter_histogram[std::min(scatter_counter, _scatter_histogram.size() - 1)]
         .pre_increment();
   }


### PR DESCRIPTION
## Description of the new code

Lewis McCallum discovered some issues when trying to compile CMacIonize on Apple's new M1 system: some integer types that did not match (`uint_fast32_t` and `uint_fast64_t` used interchangeably while they should not be), and an illegal Assembly instruction used by `cpucycle_tick()`. These have been fixed. `cpucycle_tick()` currently does not work for the M1 system.

## Impact of the new code

Nothing changed for old systems, the code now should compile and run on M1.